### PR TITLE
STYLE: Fix typo in ElevationBandsWithGlyphs.py function name,

### DIFF
--- a/src/Python/Visualization/ElevationBandsWithGlyphs.py
+++ b/src/Python/Visualization/ElevationBandsWithGlyphs.py
@@ -10,7 +10,7 @@ import vtk
 SURFACE_TYPE = {"PLANE", "SPHERE", "PARAMETRIC_SURFACE"}
 
 
-def WritePMG(ren, fn, magnification=1):
+def WritePNG(ren, fn, magnification=1):
     """
     Save the image as a PNG
     :param: ren - the renderer.
@@ -391,5 +391,5 @@ if __name__ == '__main__':
     iren = DisplaySurface("PARAMETRIC_SURFACE")
     iren.Render()
     iren.Start()
-    # WritePMG(iren.GetRenderWindow().GetRenderers().GetFirstRenderer(),
+    # WritePNG(iren.GetRenderWindow().GetRenderers().GetFirstRenderer(),
     #               "ElevationBandsWithGlyphs.png")


### PR DESCRIPTION
Fix typo in ElevationBandsWithGlyphs.py example function name: change
"WritePMG" to "WritePNG".