### PR TITLE
DOC: Fix typo in Developer instructions page.

### DIFF
--- a/src/Instructions/ForDevelopers.md
+++ b/src/Instructions/ForDevelopers.md
@@ -183,7 +183,7 @@ If your example requires arguments, you will need to edit the *CMakeLists.txt* i
 
 ## Review changes in a browser
 
-If you want to preview your changes in a browser (**NOTE:** You must have python nstalled on your system)
+If you want to preview your changes in a browser (**NOTE:** You must have python installed on your system)
 
   1. Install the markdown package for python. Go [here](https://pythonhosted.org/Markdown/install.html)
 


### PR DESCRIPTION
Fix typo in the "Review changes in a browser" section: change "nstalled"
to "installed".