### PR TITLE
DOC: Fix typos in Instructions/Guidelines.md file.

### DIFF
--- a/src/Instructions/Guidelines.md
+++ b/src/Instructions/Guidelines.md
@@ -48,7 +48,7 @@ Style](https://en.wikipedia.org/wiki/Indent_style#Allman_style). The curly brace
 * The main program must have the following signature:
 
     ```
-    int main (int argc, char *argv{})
+    int main (int argc, char *argv[])
     ```
 
     or, if argc and argv are not referenced in the code,


### PR DESCRIPTION
Fix bracket style of a program's main function signature example: change
"char *argv{}" to "char *argv[]".