### PR TITLE
ENH: Remove unused variable from vtkGlyph3D.cxx.

### DIFF
--- a/src/Cxx/Filtering/Glyph3D.cxx
+++ b/src/Cxx/Filtering/Glyph3D.cxx
@@ -22,8 +22,6 @@ int main(int, char *[])
     vtkSmartPointer<vtkPolyData>::New();
   polydata->SetPoints(points);
  
-  vtkSmartPointer<vtkPolyData> glyph = 
-    vtkSmartPointer<vtkPolyData>::New();
   // Create anything you want here, we will use a cube for the demo.
   vtkSmartPointer<vtkCubeSource> cubeSource = 
       vtkSmartPointer<vtkCubeSource>::New();


### PR DESCRIPTION
Remove unused and unnecessary variable from the vtkGlylph3D.cxx example.