### PR TITLE
Using the new API of vtkCompositeDataDisplayAttributes.

### DIFF
--- a/src/Cxx/CompositeData/CompositePolyDataMapper.cxx
+++ b/src/Cxx/CompositeData/CompositePolyDataMapper.cxx
@@ -29,17 +29,22 @@ int main( int argc, char *argv[] )
   mbds->SetBlock(2, sphere2->GetOutput());
 
   vtkNew<vtkCompositePolyDataMapper2> mapper;
-  mapper->SetInputData((vtkPolyData*)mbds.Get());
+  mapper->SetInputDataObject(mbds.GetPointer());
   vtkNew<vtkCompositeDataDisplayAttributes> cdsa;
 
-  // You can use the vtkCompositeDataDisplayAttributes to set the color
+  // You can use the vtkCompositeDataDisplayAttributes to set the color,
   // opacity and visibiliy of individual blocks of the multiblock dataset.
+  // Attributes are mapped by block pointers (vtkDataObject*), so these can
+  // be queried by their flat index through a convenience function in the
+  // attribute class (vtkCompositeDataDisplayAttributes::DataObjectFromIndex).
   // This sets the block at flat index 3 red
   // Note that the index is the flat index in the tree, so the whole multiblock
   // is index 0 and the blocks are flat indexes 1, 2 and 3.  This affects
   // the block returned by mbds->GetBlock(2).
   double color[] = {1, 0, 0};
-  cdsa->SetBlockColor(3, color);
+  unsigned int top_index = 0;
+  auto dobj = cdsa->DataObjectFromIndex(3, mbds.GetPointer(), top_index);
+  cdsa->SetBlockColor(dobj, color);
   
   mapper->SetCompositeDataDisplayAttributes(cdsa.Get());
   


### PR DESCRIPTION
Block-attributes are mapped by vtkDataObject*.