### PR TITLE
vtkVersionMacros.h needed to be included

### DIFF
--- a/src/Cxx/Rendering/WalkCow.cxx
+++ b/src/Cxx/Rendering/WalkCow.cxx
@@ -14,6 +14,7 @@
 #include <vtkRenderer.h>
 #include <vtkSmartPointer.h>
 #include <vtkTransform.h>
+#include <vtkVersionMacros.h>
 #include <vtkWindowToImageFilter.h>
 
 #include <algorithm>


### PR DESCRIPTION
Without it, VTK_MAJOR_VERSION and VTK_MINOR_VERSION macros were not
defined, leading to compile failures in VTK 8.1.