### PR TITLE
BUG: Fix SetBlockColor argument casting.

### DIFF
--- a/src/Cxx/CompositeData/CompositePolyDataMapper.cxx
+++ b/src/Cxx/CompositeData/CompositePolyDataMapper.cxx
@@ -39,10 +39,10 @@ int main( int argc, char *argv[] )
   // is index 0 and the blocks are flat indexes 1, 2 and 3.  This affects
   // the block returned by mbds->GetBlock(2).
   double color[] = {1, 0, 0};
-  cdsa->SetBlockColor(3, color);
-  
+  cdsa->SetBlockColor((vtkDataObject*)3, color);
+
   mapper->SetCompositeDataDisplayAttributes(cdsa.Get());
-  
+
   vtkNew<vtkActor> actor;
   actor->SetMapper(mapper.Get());
 


### PR DESCRIPTION
Fix `vtk::CompositeDataDisplayAttributes::SetBlockColor` first argument
type by explicitly casting to `vtkDataObject*`.