### PR TITLE
BUG: Fix VTK build using vtkExternalModuleMacros

### DIFF
--- a/CMake/WikiModuleConfig.cmake
+++ b/CMake/WikiModuleConfig.cmake
@@ -1,0 +1,41 @@
+
+#
+# This CMake module implements the logic required to build this project
+# following commit kitware/VTK@061eff0 from October 18th 2017.
+#
+# The VTK build system was one of the first modular one to be setup and
+# didn't allow to build VTK module as standalone project so that
+# they could be packaged independently and also depended one for buidling
+# other modules.
+#
+
+if(${VTK_VERSION} VERSION_LESS "8.1")
+  return()
+endif()
+
+get_filename_component(WikiExample_MODULE_CONFIG ${CMAKE_CURRENT_LIST_FILE} NAME_WE)
+message(STATUS "VTKWikiExamples:")
+message(STATUS "VTKWikiExamples: Including VTK using: ${WikiExample_MODULE_CONFIG}")
+message(STATUS "VTKWikiExamples:")
+
+if(NOT VTK_BINARY_DIR)
+  include(vtkExternalModuleMacros)
+else()
+  set(VTK_USE_FILE ${VTK_CMAKE_DIR}/UseVTK.cmake)
+endif()
+
+# Load up the CMake variables we need.
+vtk_module_export_info()
+
+# Load requested modules and their dependencies into
+# variables VTK_(DEFINITIONS|LIBRARIES|INCLUDE_DIRS|LIBRARY_DIRS).
+vtk_module_config(VTK ${${vtk-module}_DEPENDS})
+
+# Since this project does not use the regular VTK module API
+# to build the test executables (i.e. vtk_module_test_executable), the
+# required compile definitions (i.e. <module>_AUTOINIT macros needed for
+# object factory overrides initialization) are not automatically used.
+#
+# To address this, including VTK_USE_FILE ensures the compile definitions
+# are explicitly associated with the top-level project directory.
+include(${VTK_USE_FILE})

--- a/CMake/WikiModuleConfigLegacy.cmake
+++ b/CMake/WikiModuleConfigLegacy.cmake
@@ -1,5 +1,15 @@
 
 #
+# Following the improvement of VTK build system integrated in
+# commit kitware/VTK@061eff0 from October 18th 2017 the approach
+# implemented in this CMake module stopped working.
+#
+
+if(${VTK_VERSION} VERSION_EQUAL "8.1" OR ${VTK_VERSION} VERSION_GREATER "8.1")
+  return()
+endif()
+
+#
 # This CMake module implements the legacy logic that is used
 # to find and load the VTK dependencies needed by this project.
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ message(STATUS "VTKWikiExamples: VTK VERSION: ${VTK_VERSION}(${VTK_RENDERING_BAC
 set(CMAKE_MODULE_PATH
   ${WikiExamples_SOURCE_DIR}/CMake
   ${CMAKE_MODULE_PATH}
+  ${VTK_CMAKE_DIR}
   )
 
 #-----------------------------------------------------------------------------
@@ -42,6 +43,7 @@ include(WikiModuleConfigLegacy)
 if(WikiModuleConfigLegacy_RETURN)
   return()
 endif()
+include(WikiModuleConfig)
 include(WikiOutputDirectories)
 include(WikiPlatformSpecificChecks)
 include(WikiPolicies)


### PR DESCRIPTION
Hi Bill,

This PR fixes the build broken when using VTK >= kitware/VTK@061eff0, it basically improves and simplifies the build system to use `vtkExternalModuleMacros`.

For more details, see https://gitlab.kitware.com/vtk/vtk/merge_requests/3451

<hr>

```
    BUG: Fix VTK build using vtkExternalModuleMacros
    
    This commit fixes the configuration and build of VTKWikiExamples as both a
    VTK remote module and a stand-alone project. It ensure **first and follow-up
    configurations** produce similar results and behave **identically**.
    
    The build was broken following the introduction of
    Kitware/VTK@e33b90d (ExternalModule: Improve target export to
    allow build against external module).
    
    The commit addresses the issue by introducing the WikiModuleConfig CMake
    module responsible for:
    
    * ensure module information are exported into `VTK_MODULES_DIR` by using
    `vtk_module_export_info`.
    
    * use `vtk_module_config` to ensure that variables like `VTK_LIBRARIES`
    are set in the current scope when the project is build.

```

<hr>

Thanks
Jc