### PR TITLE
ENH: Update minimum required version of CMake from 2.8.8 to 3.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,4 @@
-cmake_minimum_required(VERSION 2.8.8 FATAL_ERROR)
-if (POLICY CMP0057)
-  cmake_policy(SET CMP0057 NEW)
-endif()
+cmake_minimum_required(VERSION 3.3 FATAL_ERROR)
 
 PROJECT(WikiExamples)
 


### PR DESCRIPTION
The version now match the one used in VTK 8.1.

Note that this doesn't prevent us from building against VTK6 or VTK7.