### PR TITLE
COMP: Fix configure error when build against Qt4

### DIFF
--- a/src/Cxx/Qt/CMakeLists.txt
+++ b/src/Cxx/Qt/CMakeLists.txt
@@ -60,6 +60,8 @@ foreach(EXAMPLE_FILE ${ALL_UI_FILES})
     # CMAKE_AUTOMOC in ON so the MocHdrs will be automatically wrapped.
     add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}Driver.cxx ${EXAMPLE}.cxx ${UISrcs} ${EXAMPLE}.h)
     qt5_use_modules(${WIKI}${EXAMPLE} Core Gui Widgets)
+  else()
+    add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
   endif()
   TARGET_LINK_LIBRARIES(${WIKI}${EXAMPLE} ${KIT_LIBS})
   list(REMOVE_ITEM ALL_FILES ${CMAKE_CURRENT_SOURCE_DIR}/${EXAMPLE}Driver.cxx ${CMAKE_CURRENT_SOURCE_DIR}/${EXAMPLE}.cxx)


### PR DESCRIPTION
This commit fixes the following error:

```
[...]
-- Found Qt4: /home/jcfr/Support/qt-everywhere-opensource-build-4.8.7/bin/qmake (found version "4.8.7")
CMake Error at src/Cxx/Qt/CMakeLists.txt:64 (TARGET_LINK_LIBRARIES):
  Cannot specify link libraries for target "BorderWidgetQt" which is not
  built by this project.
[...]