### PR TITLE
Fix logic.

### DIFF
--- a/src/Cxx/Visualization/Blow.cxx
+++ b/src/Cxx/Visualization/Blow.cxx
@@ -156,7 +156,7 @@ int main(int argc, char* argv[])
   auto rendererSizeY = 400;
   auto renWinScale = 0.5;
   renWin->SetWindowName("Blow");
-  if (dataPoint >= 0 and dataPoint < 10)
+  if (dataPoint >= 0 && dataPoint < 10)
   {
     renWin->AddRenderer(ren[dataPoint]);
     renWin->SetSize(rendererSizeX, rendererSizeY);

--- a/src/Python/Visualization/Blow.py
+++ b/src/Python/Visualization/Blow.py
@@ -140,7 +140,7 @@ def get_program_parameters():
         It is a translation of the original blow.tcl.
 
         data_point allows you to specify which frame is to be displayed.
-        If data_point < 0 or data_point > 9 than all ten frames are displayed.
+        If data_point < 0 or data_point > 9 all ten frames are then displayed.
 
    '''
     parser = argparse.ArgumentParser(description=description, epilog=epilogue)


### PR DESCRIPTION
I translated the c++ code from Python and accidentally left in an **and**.  My gcc compiler accepted it however Visual Studio didn't. Apparently according to this: [Logical operators](http://en.cppreference.com/w/cpp/language/operator_logical) "and", "or" and "not" can be used. This is why the gcc compiler accepted it. The things you learn!

It always pays to try different compilers!