### PR TITLE
Now using roman numerals for introductory page numbers.

### DIFF
--- a/src/VTKBookLaTex/VTKTextBook.tex
+++ b/src/VTKBookLaTex/VTKTextBook.tex
@@ -11,14 +11,14 @@
 
 \include{Definitions}
 
+\loadglsentries{Glossary}
 \makeindex
 \makeglossaries
-\loadglsentries{Glossary}
 
 %%% ----------------------------------------------------------------------
 
 \begin{document}
-%\glsaddall
+\frontmatter
 
 \include{Title}
 %%% ----------------------------------------------------------------------
@@ -27,6 +27,7 @@
 %%% ----------------------------------------------------------------------
 
 \include{Preface}
+\mainmatter
 \include{Chapter01}
 \include{Chapter02}
 \include{Chapter03}


### PR DESCRIPTION
Also \loadglsentries{Glossary} must come before \makeglossaries.