### PR TITLE
Moved VTKBookLaTeX to the VTK textbook repository.

### DIFF
--- a/src/VTKBookLaTeX/VTKTextBook.md
+++ b/src/VTKBookLaTeX/VTKTextBook.md
@@ -1,7 +1,11 @@
 # VTK Textbook - PDF Version
 
+!!! note
+    For Developers:
+    The files for the LaTeX version have been moved to the VTK repository [textbook](https://gitlab.kitware.com/vtk/textbook#), if you wish to contribute, please fork a branch from  [textbook](https://gitlab.kitware.com/vtk/textbook#).
+
 # Introduction
 
-This is a PDF version of the VTK Textbook. That is fully cross-referenced, indexed and equations and figures have been updated where possible. Figures that exist as VTK examples can be periodically updated from the regression testing of these in VTKExamples.
+This is a PDF version of the VTK Textbook. It has updated equations and figures and is fully cross-referenced and indexed. As further development occurs this text book will be updated on a rolling basis.
 
 You can download it from here: [VTKTextBook](https://raw.githubusercontent.com/lorensen/VTKExamples/master/src/VTKBookLaTeX/VTKTextBook.pdf)


### PR DESCRIPTION
The source files have been moved to to the VTK repository [textbook](https://gitlab.kitware.com/vtk/textbook#). For the interim (and as a backup) source files will still remain here.
@lorensen, I have added a note to this effect.
