### PR TITLE
VTK_OVERRIDE and VTK_DELETE_FUNCTION are deprecated

### DIFF
--- a/src/Cxx/Developers/vtkTestFilterProgressFilter.h
+++ b/src/Cxx/Developers/vtkTestFilterProgressFilter.h
@@ -1,9 +1,9 @@
 #ifndef __vtkTestFilterProgressFilter_h
 #define __vtkTestFilterProgressFilter_h
- 
+
 #include <vtkPolyDataAlgorithm.h>
- 
-class vtkTestFilterProgressFilter : public vtkPolyDataAlgorithm 
+
+class vtkTestFilterProgressFilter : public vtkPolyDataAlgorithm
 {
 public:
   static vtkTestFilterProgressFilter *New();
@@ -11,16 +11,16 @@ public:
 
 protected:
   vtkTestFilterProgressFilter();
-  ~vtkTestFilterProgressFilter() VTK_OVERRIDE {}
- 
-  int RequestData(vtkInformation *, vtkInformationVector **, vtkInformationVector *) VTK_OVERRIDE; 
- 
+  ~vtkTestFilterProgressFilter() override;
+
+  int RequestData(vtkInformation *, vtkInformationVector **, vtkInformationVector *) override;
+
   static void ProgressFunction(vtkObject* caller, long unsigned int eventId, void* clientData, void* callData);
-  
+
 private:
-  vtkTestFilterProgressFilter(const vtkTestFilterProgressFilter&) VTK_DELETE_FUNCTION;
-  void operator=(const vtkTestFilterProgressFilterr&) VTK_DELETE_FUNCTION;
- 
+  vtkTestFilterProgressFilter(const vtkTestFilterProgressFilter&) = delete;
+  void operator=(const vtkTestFilterProgressFilterr&) = delete;
+
 };
 
 #endif

--- a/src/Cxx/Developers/vtkTestFilterSelfProgressFilter.h
+++ b/src/Cxx/Developers/vtkTestFilterSelfProgressFilter.h
@@ -1,27 +1,27 @@
 #ifndef __vtkTestFilterSelfProgressFilter_h
 #define __vtkTestFilterSelfProgressFilter_h
- 
+
 #include <vtkPolyDataAlgorithm.h>
- 
-class vtkTestFilterSelfProgressFilter : public vtkPolyDataAlgorithm 
+
+class vtkTestFilterSelfProgressFilter : public vtkPolyDataAlgorithm
 {
 public:
   vtkTypeMacro(vtkTestFilterSelfProgressFilter,vtkAlgorithm);
-  
+
   static vtkTestFilterSelfProgressFilter *New();
- 
+
 protected:
   vtkTestFilterSelfProgressFilter();
-  ~vtkTestFilterSelfProgressFilter(){}
- 
-  int RequestData(vtkInformation *, vtkInformationVector **, vtkInformationVector *) VTK_OVERRIDE; 
- 
+  ~vtkTestFilterSelfProgressFilter() {}
+
+  int RequestData(vtkInformation *, vtkInformationVector **, vtkInformationVector *) override;
+
   static void ProgressFunction(vtkObject* caller, long unsigned int eventId, void* clientData, void* callData);
-  
+
 private:
-  vtkTestFilterSelfProgressFilter(const vtkTestFilterSelfProgressFilter&);  // Not implemented.
-  void operator=(const vtkTestFilterSelfProgressFilter&);  // Not implemented.
- 
+  vtkTestFilterSelfProgressFilter(const vtkTestFilterSelfProgressFilter&) = delete;
+  void operator=(const vtkTestFilterSelfProgressFilter&) = delete;
+
 };
- 
+
 #endif

--- a/src/Cxx/Developers/vtkTestMultipleInputPortsFilter.h
+++ b/src/Cxx/Developers/vtkTestMultipleInputPortsFilter.h
@@ -15,14 +15,14 @@ public:
 
 protected:
   vtkTestMultipleInputPortsFilter();
-  ~vtkTestMultipleInputPortsFilter() VTK_OVERRIDE {}
+  ~vtkTestMultipleInputPortsFilter() {}
 
-  int FillInputPortInformation( int port, vtkInformation* info ) VTK_OVERRIDE;
-  int RequestData(vtkInformation *, vtkInformationVector **, vtkInformationVector *) VTK_OVERRIDE;
+  int FillInputPortInformation( int port, vtkInformation* info ) override;
+  int RequestData(vtkInformation *, vtkInformationVector **, vtkInformationVector *) override;
 
 private:
-  vtkTestMultipleInputPortsFilter(const vtkTestMultipleInputPortsFilter&) VTK_DELETE_FUNCTION;
-  void operator=(const vtkTestMultipleInputPortsFilter&) VTK_DELETE_FUNCTION;
+  vtkTestMultipleInputPortsFilter(const vtkTestMultipleInputPortsFilter&) = delete;
+  void operator=(const vtkTestMultipleInputPortsFilter&) = delete;
 
 };
 

--- a/src/Cxx/Developers/vtkTestProgressReportFilter.h
+++ b/src/Cxx/Developers/vtkTestProgressReportFilter.h
@@ -1,24 +1,24 @@
 #ifndef __vtkTestProgressReportFilter_h
 #define __vtkTestProgressReportFilter_h
- 
+
 #include <vtkPolyDataAlgorithm.h>
- 
+
 class vtkTestProgressReportFilter : public vtkPolyDataAlgorithm
 {
 public:
   static vtkTestProgressReportFilter *New();
   vtkTypeMacro(vtkTestProgressReportFilter,vtkAlgorithm);
- 
+
 protected:
   vtkTestProgressReportFilter(){}
-  ~vtkTestProgressReportFilter() VTK_OVERRIDE {}
- 
-  int RequestData(vtkInformation *, vtkInformationVector **, vtkInformationVector *) VTK_OVERRIDE;
- 
+  ~vtkTestProgressReportFilter() {}
+
+  int RequestData(vtkInformation *, vtkInformationVector **, vtkInformationVector *) override;
+
 private:
-  vtkTestProgressReportFilter(const vtkTestProgressReportFilter&) VTK_DELETE_FUNCTION;
-  void operator=(const vtkTestProgressReportFilter&) VTK_DELETE_FUNCTION;
- 
+  vtkTestProgressReportFilter(const vtkTestProgressReportFilter&) = delete;
+  void operator=(const vtkTestProgressReportFilter&) = delete;
+
 };
- 
+
 #endif


### PR DESCRIPTION
We now use the C++11 equivalents override and delete.