### PR TITLE
ENH: Support new vtk module system

### DIFF
--- a/CMake/AddOptionalIfInLibrary.cmake
+++ b/CMake/AddOptionalIfInLibrary.cmake
@@ -1,0 +1,11 @@
+# Append a module to the list optional if the module is found in library
+macro(Add_Optional_If_In_Library module library optional)
+  set(moduleTest ${module})
+  if (VTK_VERSION VERSION_GREATER "8.4")
+    string(REGEX REPLACE "vtk" "VTK::" ${module} ${moduleTest})
+  endif()
+  list(FIND ${library} ${moduleTest} found)
+  if(found GREATER -1)
+    list(APPEND optional ${module})
+  endif()
+endmacro()

--- a/CMake/ExamplesTesting.cmake
+++ b/CMake/ExamplesTesting.cmake
@@ -25,4 +25,10 @@ include(${WikiExamples_SOURCE_DIR}/CMake/vtkTestingObjectFactory.cmake)
 add_executable(${KIT}CxxTests ${KIT}CxxTests.cxx
                ${MyTests})
 target_link_libraries(${KIT}CxxTests ${KIT_LIBS})
+if (VTK_VERSION VERSION_GREATER "8.8")
+  vtk_module_autoinit(
+    TARGETS ${KIT}CxxTests
+    MODULES ${VTK_LIBRARIES}
+    )
+endif()
 endif()

--- a/CMake/RequiresModule.cmake
+++ b/CMake/RequiresModule.cmake
@@ -1,5 +1,4 @@
 macro(Requires_Module example module)
-  if(${VTK_VERSION} VERSION_GREATER "3")
     if(NOT ${module}_LOADED)
       message(STATUS "VTKWikiExamples: ${example} requires VTK module ${module} and will not be built")
       string(REGEX REPLACE "[^;]*${example}.cxx"
@@ -7,5 +6,4 @@ macro(Requires_Module example module)
       string(REGEX REPLACE "[^;]*${example}.ui"
              "" ALL_UI_FILES "${ALL_UI_FILES}")
      endif()
-  endif()
 endmacro()

--- a/CMake/WikiLoadMacros.cmake
+++ b/CMake/WikiLoadMacros.cmake
@@ -1,0 +1,6 @@
+include(${WikiExamples_SOURCE_DIR}/CMake/AddOptionalIfInLibrary.cmake)
+include(${WikiExamples_SOURCE_DIR}/CMake/RequiresGitLfs.cmake)
+include(${WikiExamples_SOURCE_DIR}/CMake/RequiresModule.cmake)
+include(${WikiExamples_SOURCE_DIR}/CMake/RequiresSettingOff.cmake)
+include(${WikiExamples_SOURCE_DIR}/CMake/RequiresSettingOn.cmake)
+include(${WikiExamples_SOURCE_DIR}/CMake/RequiresVersion.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,11 +23,23 @@ else()
 endif()
 
 # Display VTK version
-if(NOT VTK_BINARY_DIR)
-  find_package(VTK REQUIRED)
+find_package(VTK CONFIG) 
+if (NOT VTK_FOUND)
+  message("Skipping Cube: ${VTK_NOT_FOUND_MESSAGE}")
 endif()
+
+if(NOT VTK_BINARY_DIR)
+  if (VTK_VERSION VERSION_LESS "8.90.0")
+    include(${VTK_USE_FILE})
+  endif()
+  if (NOT VTK_FOUND)
+    message("Skipping build: ${VTK_NOT_FOUND_MESSAGE}")
+    return ()
+  endif()
+endif()
+
 if(NOT VTK_RENDERING_BACKEND)
-  set(VTK_RENDERING_BACKEND OpenGL) # Support VTK version prior to introduction of rendering backend
+  set(VTK_RENDERING_BACKEND OpenGL2) # Support VTK version prior to introduction of rendering backend
 endif()
 message(STATUS "VTKWikiExamples: VTK VERSION: ${VTK_VERSION}(${VTK_RENDERING_BACKEND})")
 
@@ -39,15 +51,18 @@ set(CMAKE_MODULE_PATH
   )
 
 #-----------------------------------------------------------------------------
-include(WikiModuleConfigLegacy)
-if(WikiModuleConfigLegacy_RETURN)
-  return()
+if (VTK_VERSION VERSION_LESS "8.90.0")
+  include(WikiModuleConfigLegacy)
+  if(WikiModuleConfigLegacy_RETURN)
+    return()
+  endif()
+  include(WikiModuleConfig)
 endif()
-include(WikiModuleConfig)
 include(WikiOutputDirectories)
 include(WikiPlatformSpecificChecks)
 include(WikiPolicies)
 include(WikiTestingConfig)
+include(WikiLoadMacros)
 
 #-----------------------------------------------------------------------------
 # Mac specific

--- a/src/Admin/WhatModulesVTK.py
+++ b/src/Admin/WhatModulesVTK.py
@@ -126,6 +126,7 @@ def main(vtkSourceDir, sourceFiles):
         return
 
     # Build a set that contains all modules referenced in command line files
+    optionalModules = set()
     allModules = set()
     for inc in allIncludes:
         if inc in includesToPaths:
@@ -137,12 +138,20 @@ def main(vtkSourceDir, sourceFiles):
         allModules.add("VTK::RenderingOpenGL2")
         allModules.add("VTK::InteractionStyle")
         allModules.add("VTK::RenderingFreeType")
+        allModules.add("VTK::RenderingGL2PSOpenGL2")
+        allModules.add("VTK::RenderingContextOpenGL2")
     if "VTK::DomainsChemistry"in allModules:
         allModules.add("VTK::DomainsChemistryOpenGL2")
     if "VTK::RenderingVolume" in allModules:
         allModules.add("VTK::RenderingVolumeOpenGL2")
     if "VTK::RenderingContext2D" in allModules:
         allModules.add("VTK::RenderingContextOpenGL2")
+    if "VTK::IOExport" in allModules:
+        allModules.add("VTK::RenderingContextOpenGL2")
+        allModules.add("VTK::IOExportOpenGL2")
+        allModules.add("VTK::IOExportPDF")
+        allModules.add("VTK::RenderingContextOpenGL2")
+    optionalModules.add("VTK::TestingRendering")
 
     modules = {'All modules referenced in the files:': allModules,
               }

--- a/src/Cxx/Animation/CMakeLists.txt
+++ b/src/Cxx/Animation/CMakeLists.txt
@@ -1,19 +1,25 @@
 project (${WIKI}Animation)
 
-if(NOT WikiExamples_BINARY_DIR)
-find_package(VTK REQUIRED)
-if(NOT VTK_USE_RENDERING)
-  message(FATAL_ERROR "Example ${PROJECT_NAME} requires VTK_USE_RENDERING.")
-endif()
-include(${VTK_USE_FILE})
+if(NOT VTK_BINARY_DIR)
+  set(VTK_LIBRARIES "")
+  find_package(VTK COMPONENTS
+    vtkCommonColor
+    vtkCommonCore
+    vtkCommonDataModel
+    vtkFiltersSources
+    vtkInteractionStyle
+    vtkRenderingCore
+    vtkRenderingOpenGL2
+    vtkRenderingFreeType
+    OPTIONAL_COMPONENTS
+    vtkTestingRendering
+    )
+  if (VTK_VERSION VERSION_LESS "8.90.0")
+    include(${VTK_USE_FILE})
+  endif()
 endif()
 
-set(KIT Animation)
-if("${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}" LESS 5.8)
-  set(KIT_LIBS vtkHybrid vtkRendering)
-else()
-  set(KIT_LIBS ${VTK_LIBRARIES})
-endif()
+set(KIT_LIBS ${VTK_LIBRARIES})
 
 #
 # Build all .cxx files in the directory
@@ -22,10 +28,17 @@ foreach(SOURCE_FILE ${ALL_FILES})
   string(REPLACE ".cxx" "" TMP ${SOURCE_FILE})
   string(REPLACE ${CMAKE_CURRENT_SOURCE_DIR}/ "" EXAMPLE ${TMP})
   add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
-  target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
+  target_link_libraries(${WIKI}${EXAMPLE} PRIVATE ${KIT_LIBS})
+  if (VTK_VERSION VERSION_GREATER "8.8")
+    vtk_module_autoinit(
+      TARGETS ${WIKI}${EXAMPLE}
+      MODULES ${VTK_LIBRARIES}
+      )
+  endif()
 endforeach()
 
 # Testing
 if (BUILD_TESTING)
-include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
+  set(KIT Animation)
+  include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
 endif ()

--- a/src/Cxx/Annotation/CMakeLists.txt
+++ b/src/Cxx/Annotation/CMakeLists.txt
@@ -1,8 +1,27 @@
 project (${WIKI}Annotation)
 
-if(NOT WikiExamples_BINARY_DIR)
-find_package(VTK REQUIRED)
-  include(${VTK_USE_FILE})
+if(NOT VTK_BINARY_DIR)
+  set(VTK_LIBRARIES "")
+  find_package(VTK COMPONENTS
+    vtkCommonColor
+    vtkCommonCore
+    vtkCommonDataModel
+    vtkCommonTransforms
+    vtkFiltersCore
+    vtkFiltersGeneral
+    vtkFiltersSources
+    vtkIOParallel
+    vtkInteractionStyle
+    vtkRenderingAnnotation
+    vtkRenderingCore
+    vtkRenderingFreeType
+    vtkRenderingOpenGL2
+    OPTIONAL_COMPONENTS
+    vtkTestingRendering
+    )
+  if (VTK_VERSION VERSION_LESS "8.90.0")
+    include(${VTK_USE_FILE})
+  endif()
 endif()
 
 set(KIT_LIBS ${VTK_LIBRARIES})
@@ -17,19 +36,25 @@ foreach(SOURCE_FILE ${ALL_FILES})
   string(REPLACE ${CMAKE_CURRENT_SOURCE_DIR}/ "" EXAMPLE ${TMP})
   add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
   target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
+  if (VTK_VERSION VERSION_GREATER "8.8")
+    vtk_module_autoinit(
+      TARGETS ${WIKI}${EXAMPLE}
+      MODULES ${VTK_LIBRARIES}
+      )
+  endif()
 endforeach()
 
 if (BUILD_TESTING)
-# Testing
-set(KIT Annotation)
-set(NEEDS_ARGS
-  XYPlot
-)
+  # Testing
+  set(KIT Annotation)
+  set(NEEDS_ARGS
+    XYPlot
+    )
 
-set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
+  set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
 
-add_test(${KIT}-XYPlot ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestXYPlot ${DATA}/combxyz.bin ${DATA}/combq.bin)
+  add_test(${KIT}-XYPlot ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestXYPlot ${DATA}/combxyz.bin ${DATA}/combq.bin)
 
-include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
+  include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
 endif()

--- a/src/Cxx/CompositeData/CMakeLists.txt
+++ b/src/Cxx/CompositeData/CMakeLists.txt
@@ -1,18 +1,35 @@
 project (${WIKI}CompositeData)
 
-if(NOT WikiExamples_BINARY_DIR)
-find_package(VTK REQUIRED)
-if(NOT VTK_USE_RENDERING)
-  message(FATAL_ERROR "Example ${PROJECT_NAME} requires VTK_USE_RENDERING.")
-endif()
-include(${VTK_USE_FILE})
+if(NOT VTK_BINARY_DIR)
+  set(VTK_LIBRARIES "")
+  find_package(VTK COMPONENTS
+    vtkCommonCore
+    vtkCommonDataModel
+    vtkCommonExecutionModel
+    vtkFiltersCore
+    vtkFiltersExtraction
+    vtkFiltersGeneral
+    vtkFiltersGeometry
+    vtkFiltersModeling
+    vtkFiltersSources
+    vtkIOLegacy
+    vtkIOXML
+    vtkInteractionStyle
+    vtkRenderingCore
+    vtkRenderingFreeType
+    vtkRenderingOpenGL2
+    vtkTestingRendering
+    OPTIONAL_COMPONENTS
+    vtkRenderingGL2PSOpenGL2
+    )
+  if (VTK_VERSION VERSION_LESS "8.90.0")
+    include(${VTK_USE_FILE})
+  endif()
 endif()
 
-if("${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}" LESS 5.8)
-  set(KIT_LIBS vtkFiltering vtkHybrid)
-else()
-  set(KIT_LIBS ${VTK_LIBRARIES})
-endif()
+set(KIT CompositeData)
+set(KIT_LIBS ${VTK_LIBRARIES})
+
 #
 # Build all .cxx files in the directory
 file(GLOB ALL_FILES *.cxx)
@@ -21,26 +38,32 @@ foreach(SOURCE_FILE ${ALL_FILES})
   string(REPLACE ${CMAKE_CURRENT_SOURCE_DIR}/ "" EXAMPLE ${TMP})
   add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
   target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
+  if (NOT VTK_VERSION VERSION_LESS "8.90.0")
+    vtk_module_autoinit(
+      TARGETS ${WIKI}${EXAMPLE}
+      MODULES ${VTK_LIBRARIES}
+      )
+  endif()
 endforeach()
 
 if (BUILD_TESTING)
-# Testing
-set(KIT CompositeData)
-set(NEEDS_ARGS
-  OverlappingAMR
-)
+  # Testing
+  set(KIT CompositeData)
+  set(NEEDS_ARGS
+    OverlappingAMR
+    )
 
-set (EXCLUDE_TEST
-  HierarchicalBoxPipeline
-)
+  set (EXCLUDE_TEST
+    HierarchicalBoxPipeline
+    )
 
-add_test(${KIT}-OverlappingAMR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestOverlappingAMR -E 35)
-add_test(${KIT}-CompositePolyDataMapper ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestCompositePolyDataMapper)
-add_test(${KIT}-MultiBlockDataSet ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestMultiBlockDataSet)
+  add_test(${KIT}-OverlappingAMR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestOverlappingAMR -E 35)
+  add_test(${KIT}-CompositePolyDataMapper ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestCompositePolyDataMapper)
+  add_test(${KIT}-MultiBlockDataSet ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestMultiBlockDataSet)
 
-include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
+  include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
 
 endif()

--- a/src/Cxx/DataStructures/CMakeLists.txt
+++ b/src/Cxx/DataStructures/CMakeLists.txt
@@ -1,18 +1,34 @@
 project (${WIKI}DataStructures)
 
-if(NOT WikiExamples_BINARY_DIR)
-find_package(VTK REQUIRED)
-if(NOT VTK_USE_RENDERING)
-  message(FATAL_ERROR "Example ${PROJECT_NAME} requires VTK_USE_RENDERING.")
-endif()
-include(${VTK_USE_FILE})
+if(NOT VTK_BINARY_DIR)
+  set(VTK_LIBRARIES "")
+  find_package(VTK COMPONENTS
+    vtkChartsCore
+    vtkCommonCore
+    vtkCommonDataModel
+    vtkCommonSystem
+    vtkFiltersExtraction
+    vtkFiltersFlowPaths
+    vtkFiltersGeneral
+    vtkFiltersSources
+    vtkIOXML
+    vtkInteractionStyle
+    vtkInteractionWidgets
+    vtkRenderingContext2D
+    vtkRenderingContextOpenGL2
+    vtkRenderingCore
+    vtkRenderingFreeType
+    vtkRenderingOpenGL2
+    vtkViewsContext2D
+    OPTIONAL_COMPONENTS
+    vtkTestingRendering
+    )
+  if (VTK_VERSION VERSION_LESS "8.90.0")
+    include(${VTK_USE_FILE})
+  endif()
 endif()
 
-if("${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}" LESS 6.0)
-  set(KIT_LIBS vtkHybrid vtkRendering vtkWidgets vtkCharts)
-else()
-  set(KIT_LIBS ${VTK_LIBRARIES})
-endif()
+set(KIT_LIBS ${VTK_LIBRARIES})
 
 #
 # Build all .cxx files in the directory
@@ -22,47 +38,53 @@ foreach(SOURCE_FILE ${ALL_FILES})
   string(REPLACE ${CMAKE_CURRENT_SOURCE_DIR}/ "" EXAMPLE ${TMP})
   add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
   target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
+  if (NOT VTK_VERSION VERSION_LESS "8.90.0")
+    vtk_module_autoinit(
+      TARGETS ${WIKI}${EXAMPLE}
+      MODULES ${VTK_LIBRARIES}
+      )
+  endif()
 endforeach()
 
 if (BUILD_TESTING)
-# Testing
-set(KIT DataStructures)
-set(NEEDS_ARGS
-  DataStructureComparison
-  VisualizeKDTree
-  VisualizeOBBTree
-  KDTreeTimingDemo
-  ModifiedBSPTreeTimingDemo
-  OBBTreeTimingDemo
-  OctreeTimingDemo
-  OctreeVisualize
-)
-set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
+  # Testing
+  set(KIT DataStructures)
+  set(NEEDS_ARGS
+    DataStructureComparison
+    VisualizeKDTree
+    VisualizeOBBTree
+    KDTreeTimingDemo
+    ModifiedBSPTreeTimingDemo
+    OBBTreeTimingDemo
+    OctreeTimingDemo
+    OctreeVisualize
+    )
+  set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
 
-add_test(${KIT}-DataStructureComparison ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestDataStructureComparison ${DATA}/Bunny.vtp -E 20)
+  add_test(${KIT}-DataStructureComparison ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestDataStructureComparison ${DATA}/Bunny.vtp -E 20)
 
-add_test(${KIT}-VisualizeKDTree ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestVisualizeKDTree -E 40)
-add_test(${KIT}-VisualizeOBBTree ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestVisualizeOBBTree -E 40)
+  add_test(${KIT}-VisualizeKDTree ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestVisualizeKDTree -E 40)
+  add_test(${KIT}-VisualizeOBBTree ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestVisualizeOBBTree -E 40)
 
-# These tests will generate different output each time they run.
-# To avoid regression failures, set the error tolerance to a large number. 
-add_test(${KIT}-KDTreeTimingDemo ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestKDTreeTimingDemo -E 999999)
-add_test(${KIT}-ModifiedBSPTreeTimingDemo ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestModifiedBSPTreeTimingDemo -E 999999)
-add_test(${KIT}-OBBTreeTimingDemo ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestOBBTreeTimingDemo -E 999999)
-add_test(${KIT}-OctreeTimingDemo ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestOctreeTimingDemo -E 999999)
+  # These tests will generate different output each time they run.
+  # To avoid regression failures, set the error tolerance to a large number. 
+  add_test(${KIT}-KDTreeTimingDemo ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestKDTreeTimingDemo -E 999999)
+  add_test(${KIT}-ModifiedBSPTreeTimingDemo ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestModifiedBSPTreeTimingDemo -E 999999)
+  add_test(${KIT}-OBBTreeTimingDemo ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestOBBTreeTimingDemo -E 999999)
+  add_test(${KIT}-OctreeTimingDemo ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestOctreeTimingDemo -E 999999)
 
-add_test(${KIT}-OctreeVisualize ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestOctreeVisualize -E 40)
+  add_test(${KIT}-OctreeVisualize ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestOctreeVisualize -E 40)
 
-include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
+  include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
 
-add_subdirectory(ModifiedBSPTree)
+  add_subdirectory(ModifiedBSPTree)
 
 endif()

--- a/src/Cxx/DataStructures/ModifiedBSPTree/CMakeLists.txt
+++ b/src/Cxx/DataStructures/ModifiedBSPTree/CMakeLists.txt
@@ -1,11 +1,11 @@
 project (${WIKI}DataStructuresModifiedBSPTree)
 
 if(NOT WikiExamples_BINARY_DIR)
-find_package(VTK REQUIRED)
-if(NOT VTK_USE_RENDERING)
-  message(FATAL_ERROR "Example ${PROJECT_NAME} requires VTK_USE_RENDERING.")
-endif()
-include(${VTK_USE_FILE})
+  find_package(VTK REQUIRED)
+  if(NOT VTK_USE_RENDERING)
+    message(FATAL_ERROR "Example ${PROJECT_NAME} requires VTK_USE_RENDERING.")
+  endif()
+  include(${VTK_USE_FILE})
 endif()
 
 if("${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}" LESS 6.0)
@@ -27,7 +27,7 @@ endforeach()
 set(KIT DataStructuresModifiedBSPTree)
 set(NEEDS_ARGS
   VisualizeModifiedBSPTree
-)
+  )
 set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
 
 add_test(${KIT}-VisualizeModifiedBSPTree ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests

--- a/src/Cxx/DataStructures/Octree/CMakeLists.txt
+++ b/src/Cxx/DataStructures/Octree/CMakeLists.txt
@@ -1,11 +1,11 @@
 project (${WIKI}DataStructuresOctree)
 
 if(NOT WikiExamples_BINARY_DIR)
-find_package(VTK REQUIRED)
-if(NOT VTK_USE_RENDERING)
-  message(FATAL_ERROR "Example ${PROJECT_NAME} requires VTK_USE_RENDERING.")
-endif()
-include(${VTK_USE_FILE})
+  find_package(VTK REQUIRED)
+  if(NOT VTK_USE_RENDERING)
+    message(FATAL_ERROR "Example ${PROJECT_NAME} requires VTK_USE_RENDERING.")
+  endif()
+  include(${VTK_USE_FILE})
 endif()
 
 if("${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}" LESS 5.8)
@@ -26,7 +26,7 @@ endforeach()
 # Testing
 set(KIT DataStructuresOctree)
 set(NEEDS_ARGS
-)
+  )
 include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
 set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
 

--- a/src/Cxx/Databases/SQL/MySQL/CMakeLists.txt
+++ b/src/Cxx/Databases/SQL/MySQL/CMakeLists.txt
@@ -1,8 +1,8 @@
 project (${WIKI}MySQL)
 
 if(NOT WikiExamples_BINARY_DIR)
-find_package(VTK REQUIRED)
-include(${VTK_USE_FILE})
+  find_package(VTK REQUIRED)
+  include(${VTK_USE_FILE})
 endif()
 
 if("${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}" LESS 5.8)
@@ -23,5 +23,5 @@ endforeach()
 # Testing
 set(KIT MySQL)
 set(NEEDS_ARGS
-)
+  )
 include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)

--- a/src/Cxx/Developers/CMakeLists.txt
+++ b/src/Cxx/Developers/CMakeLists.txt
@@ -1,40 +1,89 @@
 project (${WIKI}Developers)
 
-if(NOT WikiExamples_BINARY_DIR)
-find_package(VTK REQUIRED)
-if(NOT VTK_USE_RENDERING)
-  message(FATAL_ERROR "Example ${PROJECT_NAME} requires VTK_USE_RENDERING.")
-endif()
-include(${VTK_USE_FILE})
+if(NOT VTK_BINARY_DIR)
+  set(VTK_LIBRARIES "")
+  find_package(VTK COMPONENTS
+    vtkCommonCore
+    vtkCommonDataModel
+    vtkCommonExecutionModel
+    vtkFiltersSources
+    vtkInfovisCore
+    )
+  if (VTK_VERSION VERSION_LESS "8.90.0")
+    include(${VTK_USE_FILE})
+  endif()
 endif()
 
-if("${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}" LESS 5.8)
-  set(KIT_LIBS vtkRendering vtkHybrid)
-else()
-  set(KIT_LIBS ${VTK_LIBRARIES})
-endif()
-#
+set(KIT_LIBS ${VTK_LIBRARIES})
 
 add_executable(AlgorithmFilter AlgorithmFilter vtkTestAlgorithmFilter vtkTest)
 target_link_libraries(AlgorithmFilter ${VTK_LIBRARIES})
+if (NOT VTK_VERSION VERSION_LESS "8.90.0")
+  vtk_module_autoinit(
+    TARGETS AlgorithmFilter
+    MODULES ${VTK_LIBRARIES}
+    )
+endif()
 
 add_executable(AlgorithmSource AlgorithmSource vtkTestAlgorithmSource vtkTest1)
 target_link_libraries(AlgorithmSource ${VTK_LIBRARIES})
+if (NOT VTK_VERSION VERSION_LESS "8.90.0")
+  vtk_module_autoinit(
+    TARGETS AlgorithmSource
+    MODULES ${VTK_LIBRARIES}
+    )
+endif()
 
 add_executable(ProgressReport ProgressReport.cxx vtkTestProgressReportFilter.cxx)
 target_link_libraries(ProgressReport ${VTK_LIBRARIES})
+if (NOT VTK_VERSION VERSION_LESS "8.90.0")
+  vtk_module_autoinit(
+    TARGETS ProgressReport
+    MODULES ${VTK_LIBRARIES}
+    )
+endif()
 
 add_executable(FilterSelfProgress FilterSelfProgress.cxx vtkTestFilterSelfProgressFilter.cxx)
 target_link_libraries(FilterSelfProgress ${VTK_LIBRARIES})
+if (NOT VTK_VERSION VERSION_LESS "8.90.0")
+  vtk_module_autoinit(
+    TARGETS FilterSelfProgress
+    MODULES ${VTK_LIBRARIES}
+    )
+endif()
 
 add_executable(GraphAlgorithmFilter GraphAlgorithmFilter vtkTestGraphAlgorithmFilter.cxx)
 target_link_libraries(GraphAlgorithmFilter ${VTK_LIBRARIES})
+if (NOT VTK_VERSION VERSION_LESS "8.90.0")
+  vtk_module_autoinit(
+    TARGETS GraphAlgorithmFilter
+    MODULES ${VTK_LIBRARIES}
+    )
+endif()
 
 add_executable(GraphAlgorithmSource GraphAlgorithmSource vtkTestGraphAlgorithmSource.cxx)
 target_link_libraries(GraphAlgorithmSource ${VTK_LIBRARIES})
+if (NOT VTK_VERSION VERSION_LESS "8.90.0")
+  vtk_module_autoinit(
+    TARGETS GraphAlgorithmSource
+    MODULES ${VTK_LIBRARIES}
+    )
+endif()
 
 add_executable(ImageAlgorithmFilter ImageAlgorithmFilter vtkImageAlgorithmFilter.cxx)
 target_link_libraries(ImageAlgorithmFilter ${VTK_LIBRARIES})
+if (NOT VTK_VERSION VERSION_LESS "8.90.0")
+  vtk_module_autoinit(
+    TARGETS ImageAlgorithmFilter
+    MODULES ${VTK_LIBRARIES}
+    )
+endif()
 
 add_executable(MultipleInputPorts MultipleInputPorts vtkTestMultipleInputPortsFilter)
 target_link_libraries(MultipleInputPorts ${VTK_LIBRARIES})
+if (NOT VTK_VERSION VERSION_LESS "8.90.0")
+  vtk_module_autoinit(
+    TARGETS MultipleInputPorts
+    MODULES ${VTK_LIBRARIES}
+    )
+endif()

--- a/src/Cxx/Filtering/CMakeLists.txt
+++ b/src/Cxx/Filtering/CMakeLists.txt
@@ -1,61 +1,82 @@
 project (${WIKI}Filtering)
 
-if(NOT WikiExamples_BINARY_DIR)
-find_package(VTK REQUIRED)
-if(NOT VTK_USE_RENDERING)
-  message(FATAL_ERROR "Example ${PROJECT_NAME} requires VTK_USE_RENDERING.")
-endif()
-include(${VTK_USE_FILE})
+if(NOT VTK_BINARY_DIR)
+  set(VTK_LIBRARIES "")
+  find_package(VTK COMPONENTS
+    vtkCommonColor
+    vtkCommonCore
+    vtkCommonDataModel
+    vtkCommonMath
+    vtkCommonTransforms
+    vtkFiltersCore
+    vtkFiltersExtraction
+    vtkFiltersGeneral
+    vtkFiltersGeneric
+    vtkFiltersModeling
+    vtkFiltersProgrammable
+    vtkFiltersSources
+    vtkIOXML
+    vtkImagingHybrid
+    vtkImagingMath
+    vtkInteractionStyle
+    vtkRenderingCore
+    vtkRenderingFreeType
+    vtkRenderingOpenGL2
+    vtkTestingGenericBridge
+    OPTIONAL_COMPONENTS
+    vtkTestingRendering
+    )
+  if (VTK_VERSION VERSION_LESS "8.90.0")
+    include(${VTK_USE_FILE})
+  endif()
 endif()
 
-if("${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}" LESS 5.8)
-  set(KIT_LIBS vtkRendering vtkHybrid)
-else()
-  set(KIT_LIBS ${VTK_LIBRARIES})
-endif()
+set(KIT_LIBS ${VTK_LIBRARIES})
+
 #
 # Build all .cxx files in the directory
 file(GLOB ALL_FILES *.cxx)
 
-include(${WikiExamples_SOURCE_DIR}/CMake/RequiresVersion.cmake)
-include(${WikiExamples_SOURCE_DIR}/CMake/RequiresModule.cmake)
-include(${WikiExamples_SOURCE_DIR}/CMake/RequiresSettingOn.cmake)
-
 set(VERSION_MIN "6.0")
 Requires_Version(GenericClip ${VERSION_MIN} ALL_FILES)
 Requires_Setting_On (GenericClip BUILD_TESTING)
-
 
 foreach(SOURCE_FILE ${ALL_FILES})
   string(REPLACE ".cxx" "" TMP ${SOURCE_FILE})
   string(REPLACE ${CMAKE_CURRENT_SOURCE_DIR}/ "" EXAMPLE ${TMP})
   add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
   target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
+  if (VTK_VERSION VERSION_GREATER "8.8")
+    vtk_module_autoinit(
+      TARGETS ${WIKI}${EXAMPLE}
+      MODULES ${VTK_LIBRARIES}
+      )
+  endif()
 endforeach()
 
 if (BUILD_TESTING)
-# Testing
-set(KIT Filtering)
-set(NEEDS_ARGS
-  ConstrainedDelaunay2D
-  ContoursFromPolyData
-  ConstrainedDelaunay2D
-  ICPRealData
-  SurfaceFromUnorganizedPoints
-)
+  # Testing
+  set(KIT Filtering)
+  set(NEEDS_ARGS
+    ConstrainedDelaunay2D
+    ContoursFromPolyData
+    ConstrainedDelaunay2D
+    ICPRealData
+    SurfaceFromUnorganizedPoints
+    )
 
-set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
-add_test(${KIT}-ConstrainedDelaunay2D ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestConstrainedDelaunay2D -E 30)
+  set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
+  add_test(${KIT}-ConstrainedDelaunay2D ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestConstrainedDelaunay2D -E 30)
 
-add_test(${KIT}-Delaunay2D ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestDelaunay2D -E 30)
+  add_test(${KIT}-Delaunay2D ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestDelaunay2D -E 30)
 
-add_test(${KIT}-SurfaceFromUnorganizedPoints ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestSurfaceFromUnorganizedPoints ${DATA}/Bunny.vtp -E 30)
+  add_test(${KIT}-SurfaceFromUnorganizedPoints ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestSurfaceFromUnorganizedPoints ${DATA}/Bunny.vtp -E 30)
 
-add_test(${KIT}-ContoursFromPolyData ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestContoursFromPolyData ${DATA}/Bunny.vtp  -E 30)
-include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
+  add_test(${KIT}-ContoursFromPolyData ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestContoursFromPolyData ${DATA}/Bunny.vtp  -E 30)
+  include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
 
 endif()

--- a/src/Cxx/GeometricObjects/CMakeLists.txt
+++ b/src/Cxx/GeometricObjects/CMakeLists.txt
@@ -1,8 +1,32 @@
 project (${WIKI}GeometricObjects)
 
-if(NOT WikiExamples_BINARY_DIR)
-  find_package(VTK REQUIRED)
-  include(${VTK_USE_FILE})
+if(NOT VTK_BINARY_DIR)
+  set(VTK_LIBRARIES "")
+  find_package(VTK COMPONENTS
+    vtkCommonColor
+    vtkCommonComputationalGeometry
+    vtkCommonCore
+    vtkCommonDataModel
+    vtkCommonExecutionModel
+    vtkCommonTransforms
+    vtkFiltersCore
+    vtkFiltersGeneral
+    vtkFiltersModeling
+    vtkFiltersSources
+    vtkIOXML
+    vtkInteractionStyle
+    vtkInteractionWidgets
+    vtkRenderingAnnotation
+    vtkRenderingCore
+    vtkRenderingFreeType
+    vtkRenderingLabel
+    vtkRenderingOpenGL2
+    OPTIONAL_COMPONENTS
+    vtkTestingRendering
+    )
+  if (VTK_VERSION VERSION_LESS "8.90.0")
+    include(${VTK_USE_FILE})
+  endif()
 endif()
 
 set(KIT_LIBS ${VTK_LIBRARIES})
@@ -11,7 +35,6 @@ set(KIT_LIBS ${VTK_LIBRARIES})
 # Build all .cxx files in the directory
 file(GLOB ALL_FILES *.cxx)
 
-include(${WikiExamples_SOURCE_DIR}/CMake/RequiresVersion.cmake)
 set(VERSION_MIN "7.0")
 Requires_Version(ParametricKuenDemo ${VERSION_MIN} ALL_FILES)
 Requires_Version(ParametricObjectsDemo2 ${VERSION_MIN} ALL_FILES)
@@ -29,21 +52,27 @@ foreach(SOURCE_FILE ${ALL_FILES})
   string(REPLACE ${CMAKE_CURRENT_SOURCE_DIR}/ "" EXAMPLE ${TMP})
   add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
   target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
+  if (NOT VTK_VERSION VERSION_LESS "8.90.0")
+    vtk_module_autoinit(
+      TARGETS ${WIKI}${EXAMPLE}
+      MODULES ${VTK_LIBRARIES}
+      )
+  endif()
 endforeach()
 
 if (BUILD_TESTING)
-# Testing
-set(KIT GeometricObjects)
-set(NEEDS_ARGS
+  # Testing
+  set(KIT GeometricObjects)
+  set(NEEDS_ARGS
     QuadraticHexahedron
     TessellatedBoxSource
-)
+    )
 
-add_test(${KIT}-QuadraticHexahedron ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestQuadraticHexahedron -E 30)
+  add_test(${KIT}-QuadraticHexahedron ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestQuadraticHexahedron -E 30)
 
-add_test(${KIT}-TessellatedBoxSource ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestTessellatedBoxSource -E 30)
+  add_test(${KIT}-TessellatedBoxSource ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestTessellatedBoxSource -E 30)
 
-include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
+  include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
 endif()

--- a/src/Cxx/Geovis/CMakeLists.txt
+++ b/src/Cxx/Geovis/CMakeLists.txt
@@ -1,8 +1,26 @@
 project (${WIKI}Geovis)
 
-if(NOT WikiExamples_BINARY_DIR)
-  find_package(VTK REQUIRED)
-  include(${VTK_USE_FILE})
+if(NOT VTK_BINARY_DIR)
+  set(VTK_LIBRARIES "")
+  find_package(VTK COMPONENTS
+    vtkCommonColor
+    vtkCommonCore
+    vtkCommonDataModel
+    vtkFiltersGeneral
+    vtkFiltersHybrid
+    vtkFiltersSources
+    vtkGeovisCore
+    vtkIOXML
+    vtkInteractionStyle
+    vtkRenderingCore
+    vtkRenderingFreeType
+    vtkRenderingOpenGL2
+    OPTIONAL_COMPONENTS
+    vtkTestingRendering
+    )
+  if (VTK_VERSION VERSION_LESS "8.90.0")
+    include(${VTK_USE_FILE})
+  endif()
 endif()
 
 set(KIT_LIBS ${VTK_LIBRARIES})
@@ -14,7 +32,7 @@ if(VTK_LEGACY_REMOVE)
   list(APPEND DEPRC_SRCS
     GeoGraticle.cxx
     GeoAssignCoordinates.cxx
-  )
+    )
 endif()
 file(GLOB ALL_FILES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.cxx)
 if (DEPRC_SRCS)
@@ -22,7 +40,6 @@ if (DEPRC_SRCS)
 endif()
 
 if(NOT VTK_LEGACY_REMOVE)
-  include(${WikiExamples_SOURCE_DIR}/CMake/RequiresModule.cmake)
   Requires_Module(GeoGraticle vtkViewsGeovis)
 endif()
 
@@ -30,19 +47,25 @@ foreach(SOURCE_FILE ${ALL_FILES})
   string(REPLACE ".cxx" "" EXAMPLE ${SOURCE_FILE})
   add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
   target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
+  if (NOT VTK_VERSION VERSION_LESS "8.90.0")
+    vtk_module_autoinit(
+      TARGETS ${WIKI}${EXAMPLE}
+      MODULES ${VTK_LIBRARIES}
+      )
+  endif()
 endforeach()
 
 if (BUILD_TESTING)
-# Testing
-set(KIT Geovis)
-if(NOT VTK_LEGACY_REMOVE)
-  set(NEEDS_ARGS
-    GeoGraticule
-  )
-  if (vtkViewsGeovis_LOADED)
-    add_test(${KIT}-GeoGraticle ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-      TestGeoGraticle ${DATA}/political.vtp)
+  # Testing
+  set(KIT Geovis)
+  if(NOT VTK_LEGACY_REMOVE)
+    set(NEEDS_ARGS
+      GeoGraticule
+      )
+    if (vtkViewsGeovis_LOADED)
+      add_test(${KIT}-GeoGraticle ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+        TestGeoGraticle ${DATA}/political.vtp)
+    endif()
   endif()
-endif()
-include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
+  include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
 endif()

--- a/src/Cxx/Graphs/CMakeLists.txt
+++ b/src/Cxx/Graphs/CMakeLists.txt
@@ -1,18 +1,35 @@
 project (${WIKI}Graphs)
 
-if(NOT WikiExamples_BINARY_DIR)
-find_package(VTK REQUIRED)
-if(NOT VTK_USE_RENDERING)
-  message(FATAL_ERROR "Example ${PROJECT_NAME} requires VTK_USE_RENDERING.")
-endif()
-include(${VTK_USE_FILE})
+if(NOT VTK_BINARY_DIR)
+  set(VTK_LIBRARIES "")
+  find_package(VTK COMPONENTS
+    vtkCommonCore
+    vtkCommonDataModel
+    vtkFiltersCore
+    vtkFiltersGeneral
+    vtkFiltersModeling
+    vtkFiltersSources
+    vtkIOLegacy
+    vtkIOXML
+    vtkInfovisBoostGraphAlgorithms
+    vtkInfovisCore
+    vtkInfovisLayout
+    vtkInteractionStyle
+    vtkRenderingCore
+    vtkRenderingFreeType
+    vtkRenderingOpenGL2
+    vtkViewsCore
+    vtkViewsInfovis
+    OPTIONAL_COMPONENTS
+    vtkTestingRendering
+    )
+  if (VTK_VERSION VERSION_LESS "8.90.0")
+    include(${VTK_USE_FILE})
+  endif()
 endif()
 
-if("${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}" LESS 5.8)
-  set(KIT_LIBS vtkViews vtkHybrid)
-else()
-  set(KIT_LIBS ${VTK_LIBRARIES})
-endif()
+set(KIT_LIBS ${VTK_LIBRARIES})
+
 #
 # Build all .cxx files in the directory
 file(GLOB ALL_FILES *.cxx)
@@ -21,10 +38,17 @@ foreach(SOURCE_FILE ${ALL_FILES})
   string(REPLACE ${CMAKE_CURRENT_SOURCE_DIR}/ "" EXAMPLE ${TMP})
   add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
   target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
-endforeach()
+  if (NOT VTK_VERSION VERSION_LESS "8.90.0")
+    vtk_module_autoinit(
+      TARGETS ${WIKI}${EXAMPLE}
+      MODULES ${VTK_LIBRARIES}
+      )
+  endforeach()
 
-# Testing
-set(KIT Graphs)
-set(NEEDS_ARGS
-)
-include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
+  if (BUILD_TESTING)
+    # Testing
+    set(KIT Graphs)
+    set(NEEDS_ARGS
+      )
+  endif()
+  include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)

--- a/src/Cxx/HyperTreeGrid/CMakeLists.txt
+++ b/src/Cxx/HyperTreeGrid/CMakeLists.txt
@@ -1,11 +1,21 @@
 project (${WIKI}HyperTreeGrid)
 
-if(NOT WikiExamples_BINARY_DIR)
-find_package(VTK REQUIRED)
-if(NOT VTK_USE_RENDERING)
-  message(FATAL_ERROR "Example ${PROJECT_NAME} requires VTK_USE_RENDERING.")
-endif()
-include(${VTK_USE_FILE})
+if(NOT VTK_BINARY_DIR)
+  set(VTK_LIBRARIES "")
+  find_package(VTK COMPONENTS
+    vtkCommonColor
+    vtkFiltersGeneral
+    vtkFiltersSources
+    vtkInteractionStyle
+    vtkRenderingCore
+    vtkRenderingFreeType
+    vtkRenderingOpenGL2
+    OPTIONAL_COMPONENTS
+    vtkTestingRendering
+    )
+  if (VTK_VERSION VERSION_LESS "8.90.0")
+    include(${VTK_USE_FILE})
+  endif()
 endif()
 
 set(KIT_LIBS ${VTK_LIBRARIES})
@@ -24,13 +34,18 @@ foreach(SOURCE_FILE ${ALL_FILES})
   string(REPLACE ${CMAKE_CURRENT_SOURCE_DIR}/ "" EXAMPLE ${TMP})
   add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
   target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
+  if (NOT VTK_VERSION VERSION_LESS "8.90.0")
+    vtk_module_autoinit(
+      TARGETS ${WIKI}${EXAMPLE}
+      MODULES ${VTK_LIBRARIES}
+      )
+  endif()
 endforeach()
 
 if (BUILD_TESTING)
-# Testing
-set(KIT HyperTreeGrid)
-set(NEEDS_ARGS
-)
-
-include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
+  # Testing
+  set(KIT HyperTreeGrid)
+  set(NEEDS_ARGS
+    )
+  include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
 endif()

--- a/src/Cxx/IO/CMakeLists.txt
+++ b/src/Cxx/IO/CMakeLists.txt
@@ -1,8 +1,47 @@
 project (${WIKI}IO)
 
-if(NOT WikiExamples_BINARY_DIR)
-  find_package(VTK REQUIRED)
-  include(${VTK_USE_FILE})
+if(NOT VTK_BINARY_DIR)
+  find_package(VTK COMPONENTS
+    vtkChartsCore
+    vtkCommonColor
+    vtkCommonCore
+    vtkCommonDataModel
+    vtkCommonSystem
+    vtkCommonTransforms
+    vtkFiltersCore
+    vtkFiltersExtraction
+    vtkFiltersGeneral
+    vtkFiltersGeometry
+    vtkFiltersModeling
+    vtkFiltersSources
+    vtkIOExodus
+    vtkIOGeometry
+    vtkIOImage
+    vtkIOImport
+    vtkIOLegacy
+    vtkIOPLY
+    vtkIOParallel
+    vtkIOParallelXML
+    vtkIOXML
+    vtkImagingCore
+    vtkImagingSources
+    vtkInteractionImage
+    vtkInteractionStyle
+    vtkRenderingAnnotation
+    vtkRenderingContext2D
+    vtkRenderingContextOpenGL2
+    vtkRenderingCore
+    vtkRenderingFreeType
+    vtkRenderingLOD
+    vtkRenderingLabel
+    vtkRenderingOpenGL2
+    vtkViewsContext2D
+    OPTIONAL_COMPONENTS
+    vtkTestingRendering
+    )
+  if (VTK_VERSION VERSION_LESS "8.90.0")
+    include(${VTK_USE_FILE})
+  endif()
 endif()
 
 set(KIT_LIBS ${VTK_LIBRARIES})
@@ -10,8 +49,6 @@ set(KIT_LIBS ${VTK_LIBRARIES})
 #
 # Build all .cxx files in the directory
 file(GLOB ALL_FILES *.cxx)
-
-include(${WikiExamples_SOURCE_DIR}/CMake/RequiresGitLfs.cmake)
 
 Requires_GitLfs(DEMReader ALL_FILES)
 Requires_GitLfs(ReadSLC ALL_FILES)
@@ -21,222 +58,228 @@ foreach(SOURCE_FILE ${ALL_FILES})
   string(REPLACE ${CMAKE_CURRENT_SOURCE_DIR}/ "" EXAMPLE ${TMP})
   add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
   target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
+  if (NOT VTK_VERSION VERSION_LESS "8.90.0")
+    vtk_module_autoinit(
+      TARGETS ${WIKI}${EXAMPLE}
+      MODULES ${VTK_LIBRARIES}
+      )
+  endif()
 endforeach()
 
 if (BUILD_TESTING)
-# Testing
-set(KIT IO)
-set(NEEDS_ARGS
-  3DSImporter
-  ConvertFile
-  DEMReader
-  DumpXMLFile
-  ExportPolyDataScene
-  GenericDataObjectReader
-  ImageReader2Factory
-  ImportPolyDataScene
-  IndividualVRML
-  JPEGReader
-  JPEGWriter
-  MetaImageReader
-  OBJImporter
-  ParticleReader
-  PNGReader
-  PNGWriter
-  ReadAllPolyDataTypes
-  ReadAllPolyDataTypesDemo
-  ReadBMP
-  ReadDICOM
-  ReadDICOMSeries
-  ReadExodusData
-  ReadImageData
-  ReadLegacyUnstructuredGrid
-  ReadOBJ
-  ReadPDB
-  ReadPlainTextTriangles
-  ReadPLY
-  ReadPLOT3D
-  ReadPNM
-  ReadPolyData
-  ReadRectilinearGrid
-  ReadSTL
-  ReadSLC
-  ReadStructuredGrid
-  ReadTIFF
-  ReadTextFile
-  ReadUnknownTypeXMLFile
-  ReadUnstructuredGrid
-  SimplePointsReader
-  StructuredPointsReader
-  StructuredGridReader
-  VRMLImporter
-  VRMLImporterDemo
-  WriteBMP
-  WritePLY
-  WritePNM
-  WriteSTL
-  WriteTIFF
-  WriteVTI
-  WriteVTU
-)
- 
-set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
-set(TEMP ${WikiExamples_BINARY_DIR}/Testing/Temporary)
+  # Testing
+  set(KIT IO)
+  set(NEEDS_ARGS
+    3DSImporter
+    ConvertFile
+    DEMReader
+    DumpXMLFile
+    ExportPolyDataScene
+    GenericDataObjectReader
+    ImageReader2Factory
+    ImportPolyDataScene
+    IndividualVRML
+    JPEGReader
+    JPEGWriter
+    MetaImageReader
+    OBJImporter
+    ParticleReader
+    PNGReader
+    PNGWriter
+    ReadAllPolyDataTypes
+    ReadAllPolyDataTypesDemo
+    ReadBMP
+    ReadDICOM
+    ReadDICOMSeries
+    ReadExodusData
+    ReadImageData
+    ReadLegacyUnstructuredGrid
+    ReadOBJ
+    ReadPDB
+    ReadPlainTextTriangles
+    ReadPLY
+    ReadPLOT3D
+    ReadPNM
+    ReadPolyData
+    ReadRectilinearGrid
+    ReadSTL
+    ReadSLC
+    ReadStructuredGrid
+    ReadTIFF
+    ReadTextFile
+    ReadUnknownTypeXMLFile
+    ReadUnstructuredGrid
+    SimplePointsReader
+    StructuredPointsReader
+    StructuredGridReader
+    VRMLImporter
+    VRMLImporterDemo
+    WriteBMP
+    WritePLY
+    WritePNM
+    WriteSTL
+    WriteTIFF
+    WriteVTI
+    WriteVTU
+    )
+  
+  set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
+  set(TEMP ${WikiExamples_BINARY_DIR}/Testing/Temporary)
 
-add_test(${KIT}-3DSImporter ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  Test3DSImporter ${DATA}/iflamingo.3ds)
+  add_test(${KIT}-3DSImporter ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    Test3DSImporter ${DATA}/iflamingo.3ds)
 
-add_test(${KIT}-ConvertFile ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestConvertFile ${DATA}/Bunny.vtp ${TEMP}/ConvertFile.ply)
+  add_test(${KIT}-ConvertFile ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestConvertFile ${DATA}/Bunny.vtp ${TEMP}/ConvertFile.ply)
 
-add_test(${KIT}-DumpXMLFile ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestDumpXMLFile ${DATA}/Bunny.vtp)
+  add_test(${KIT}-DumpXMLFile ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestDumpXMLFile ${DATA}/Bunny.vtp)
 
-add_test(${KIT}-ExportPolyDataScene ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestExportPolyDataScene ${DATA}/Bunny.vtp)
+  add_test(${KIT}-ExportPolyDataScene ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestExportPolyDataScene ${DATA}/Bunny.vtp)
 
-add_test(${KIT}-ImportPolyDataScene ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestImportPolyDataScene ${DATA}/ExportBunny.vtp)
+  add_test(${KIT}-ImportPolyDataScene ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestImportPolyDataScene ${DATA}/ExportBunny.vtp)
 
-add_test(${KIT}-GenericDataObjectReader ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestGenericDataObjectReader ${DATA}/Bunny.vtp)
+  add_test(${KIT}-GenericDataObjectReader ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestGenericDataObjectReader ${DATA}/Bunny.vtp)
 
-add_test(${KIT}-IndividualVRML ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestIndividualVRML ${DATA}/teapot.wrl teapot)
+  add_test(${KIT}-IndividualVRML ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestIndividualVRML ${DATA}/teapot.wrl teapot)
 
-add_test(${KIT}-ImageReader2Factory ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestImageReader2Factory ${DATA}/Gourds.png)
+  add_test(${KIT}-ImageReader2Factory ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestImageReader2Factory ${DATA}/Gourds.png)
 
-add_test(${KIT}-JPEGReader ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestJPEGReader ${DATA}/Pileated.jpg)
+  add_test(${KIT}-JPEGReader ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestJPEGReader ${DATA}/Pileated.jpg)
 
-add_test(${KIT}-JPEGWriter ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestJPEGWriter ${TEMP}/JPEGWriter.jpg)
+  add_test(${KIT}-JPEGWriter ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestJPEGWriter ${TEMP}/JPEGWriter.jpg)
 
-add_test(${KIT}-MetaImageReader ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestMetaImageReader ${DATA}/Gourds.mha)
+  add_test(${KIT}-MetaImageReader ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestMetaImageReader ${DATA}/Gourds.mha)
 
-add_test(${KIT}-OBJImporter ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestOBJImporter ${DATA}/doorman/doorman.obj ${DATA}/doorman/doorman.mtl ${DATA}/doorman)
+  add_test(${KIT}-OBJImporter ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestOBJImporter ${DATA}/doorman/doorman.obj ${DATA}/doorman/doorman.mtl ${DATA}/doorman)
 
-add_test(${KIT}-ParticleReader ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestParticleReader ${DATA}/Particles.raw)
+  add_test(${KIT}-ParticleReader ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestParticleReader ${DATA}/Particles.raw)
 
-add_test(${KIT}-PNGReader ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestPNGReader ${DATA}/Gourds.png)
+  add_test(${KIT}-PNGReader ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestPNGReader ${DATA}/Gourds.png)
 
-add_test(${KIT}-PNGWriter ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestPNGWriter ${TEMP}/PNGWriter.png)
+  add_test(${KIT}-PNGWriter ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestPNGWriter ${TEMP}/PNGWriter.png)
 
-add_test(${KIT}-ReadAllPolyDataTypes ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestReadAllPolyDataTypes ${DATA}/horse.ply)
+  add_test(${KIT}-ReadAllPolyDataTypes ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestReadAllPolyDataTypes ${DATA}/horse.ply)
 
-add_test(${KIT}-ReadAllPolyDataTypesDemo ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+  add_test(${KIT}-ReadAllPolyDataTypesDemo ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
     TestReadAllPolyDataTypesDemo ${DATA}/teapot.g ${DATA}/cowHead.vtp ${DATA}/horse.ply ${DATA}/trumpet.obj ${DATA}/42400-IDGH.stl ${DATA}/v.vtk)
 
-add_test(${KIT}-ReadBMP ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestReadBMP ${DATA}/masonry.bmp)
+  add_test(${KIT}-ReadBMP ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestReadBMP ${DATA}/masonry.bmp)
 
-add_test(${KIT}-ReadDICOM ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestReadDICOM ${DATA}/prostate.img)
+  add_test(${KIT}-ReadDICOM ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestReadDICOM ${DATA}/prostate.img)
 
-add_test(${KIT}-ReadDICOMSeries ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestReadDICOMSeries ${DATA}/DICOMDirectory)
+  add_test(${KIT}-ReadDICOMSeries ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestReadDICOMSeries ${DATA}/DICOMDirectory)
 
-add_test(${KIT}-ReadExodusData ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestReadExodusData ${DATA}/mug.e convected)
+  add_test(${KIT}-ReadExodusData ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestReadExodusData ${DATA}/mug.e convected)
 
-add_test(${KIT}-ReadImageData ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestReadImageData ${DATA}/vase.vti)
+  add_test(${KIT}-ReadImageData ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestReadImageData ${DATA}/vase.vti)
 
-add_test(${KIT}-ReadLegacyUnstructuredGrid ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestReadLegacyUnstructuredGrid ${DATA}/VTKCellTypes.vtk)
+  add_test(${KIT}-ReadLegacyUnstructuredGrid ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestReadLegacyUnstructuredGrid ${DATA}/VTKCellTypes.vtk)
 
-add_test(${KIT}-ReadOBJ ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestReadOBJ ${DATA}/trumpet.obj)
+  add_test(${KIT}-ReadOBJ ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestReadOBJ ${DATA}/trumpet.obj)
 
-add_test(${KIT}-ReadPDB ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestReadPDB ${DATA}/lys.pdb)
+  add_test(${KIT}-ReadPDB ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestReadPDB ${DATA}/lys.pdb)
 
-add_test(${KIT}-ReadPLOT3D ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestReadPLOT3D ${DATA}/combxyz.bin ${DATA}/combq.bin)
+  add_test(${KIT}-ReadPLOT3D ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestReadPLOT3D ${DATA}/combxyz.bin ${DATA}/combq.bin)
 
-add_test(${KIT}-ReadPLY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestReadPLY ${DATA}/shark.ply)
+  add_test(${KIT}-ReadPLY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestReadPLY ${DATA}/shark.ply)
 
-add_test(${KIT}-ReadPolyData ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestReadPolyData ${DATA}/Torso.vtp)
+  add_test(${KIT}-ReadPolyData ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestReadPolyData ${DATA}/Torso.vtp)
 
-add_test(${KIT}-ReadPNM ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestReadPNM ${DATA}/Gourds.pnm)
+  add_test(${KIT}-ReadPNM ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestReadPNM ${DATA}/Gourds.pnm)
 
-add_test(${KIT}-ReadRectilinearGrid ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestReadRectilinearGrid ${DATA}/RectilinearGrid.vtr)
+  add_test(${KIT}-ReadRectilinearGrid ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestReadRectilinearGrid ${DATA}/RectilinearGrid.vtr)
 
-add_test(${KIT}-ReadSTL ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestReadSTL ${DATA}/42400-IDGH.stl)
+  add_test(${KIT}-ReadSTL ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestReadSTL ${DATA}/42400-IDGH.stl)
   
-add_test(${KIT}-ReadStructuredGrid ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestReadStructuredGrid ${DATA}/StructuredGrid.vts)
+  add_test(${KIT}-ReadStructuredGrid ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestReadStructuredGrid ${DATA}/StructuredGrid.vts)
 
-add_test(${KIT}-ReadPlainTextTriangles ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestReadPlainTextTriangles ${DATA}/Triangles.txt)
+  add_test(${KIT}-ReadPlainTextTriangles ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestReadPlainTextTriangles ${DATA}/Triangles.txt)
 
-add_test(${KIT}-ReadUnknownTypeXMLFile ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestReadUnknownTypeXMLFile ${DATA}/Bunny.vtp)
+  add_test(${KIT}-ReadUnknownTypeXMLFile ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestReadUnknownTypeXMLFile ${DATA}/Bunny.vtp)
 
-add_test(${KIT}-ReadTIFF ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestReadTIFF ${DATA}/ColorCells.tif)
+  add_test(${KIT}-ReadTIFF ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestReadTIFF ${DATA}/ColorCells.tif)
 
-add_test(${KIT}-ReadTextFile ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestReadTextFile ${DATA}/TeapotPoints.txt)
+  add_test(${KIT}-ReadTextFile ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestReadTextFile ${DATA}/TeapotPoints.txt)
 
-add_test(${KIT}-ReadUnstructuredGrid ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestReadUnstructuredGrid ${DATA}/tetra.vtu)
+  add_test(${KIT}-ReadUnstructuredGrid ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestReadUnstructuredGrid ${DATA}/tetra.vtu)
 
-add_test(${KIT}-SimplePointsReader ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestSimplePointsReader ${DATA}/coords.txt)
+  add_test(${KIT}-SimplePointsReader ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestSimplePointsReader ${DATA}/coords.txt)
 
-add_test(${KIT}-StructuredPointsReader ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestStructuredPointsReader ${DATA}/StructuredPoints.vtk)
+  add_test(${KIT}-StructuredPointsReader ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestStructuredPointsReader ${DATA}/StructuredPoints.vtk)
 
-add_test(${KIT}-StructuredGridReader ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestStructuredGridReader ${DATA}/SampleStructGrid.vtk)
+  add_test(${KIT}-StructuredGridReader ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestStructuredGridReader ${DATA}/SampleStructGrid.vtk)
 
-add_test(${KIT}-VRMLImporter ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestVRMLImporter ${DATA}/sextant.wrl -E 30)
+  add_test(${KIT}-VRMLImporter ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestVRMLImporter ${DATA}/sextant.wrl -E 30)
 
-add_test(${KIT}-VRMLImporterDemo ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestVRMLImporterDemo ${DATA}/grasshop.wrl)
+  add_test(${KIT}-VRMLImporterDemo ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestVRMLImporterDemo ${DATA}/grasshop.wrl)
 
-add_test(${KIT}-WriteBMP ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestWriteBMP ${TEMP}/WriteBMP.bmp)
+  add_test(${KIT}-WriteBMP ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestWriteBMP ${TEMP}/WriteBMP.bmp)
 
-add_test(${KIT}-WritePNM ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestWritePNM ${TEMP}/WritePNM.pnm)
+  add_test(${KIT}-WritePNM ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestWritePNM ${TEMP}/WritePNM.pnm)
 
-add_test(${KIT}-WritePLY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestWritePLY ${TEMP}/WritePLY.ply)
+  add_test(${KIT}-WritePLY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestWritePLY ${TEMP}/WritePLY.ply)
 
-add_test(${KIT}-WriteSTL ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestWriteSTL ${TEMP}/WriteSTL.stl)
+  add_test(${KIT}-WriteSTL ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestWriteSTL ${TEMP}/WriteSTL.stl)
 
-add_test(${KIT}-WriteTIFF ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestWriteTIFF ${TEMP}/WriteTIFF.tif)
+  add_test(${KIT}-WriteTIFF ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestWriteTIFF ${TEMP}/WriteTIFF.tif)
 
-add_test(${KIT}-WriteVTI ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestWriteVTI ${TEMP}/WriteVTI.vti)
+  add_test(${KIT}-WriteVTI ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestWriteVTI ${TEMP}/WriteVTI.vti)
 
-add_test(${KIT}-WriteVTU ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestWriteVTU ${TEMP}/WriteVTU.vtu)
+  add_test(${KIT}-WriteVTU ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestWriteVTU ${TEMP}/WriteVTU.vtu)
 
-# These tests use git large file system data
-if(GIT_LFS)
-  add_test(${KIT}-DEMReader ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-    TestDEMReader ${DATA}/SainteHelens.dem)
-  add_test(${KIT}-ReadSLC ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-    TestReadSLC ${DATA}/vw_knee.slc 72.0)
-endif()
+  # These tests use git large file system data
+  if(GIT_LFS)
+    add_test(${KIT}-DEMReader ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+      TestDEMReader ${DATA}/SainteHelens.dem)
+    add_test(${KIT}-ReadSLC ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+      TestReadSLC ${DATA}/vw_knee.slc 72.0)
+  endif()
 
-include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
+  include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
 endif()

--- a/src/Cxx/ImageData/CMakeLists.txt
+++ b/src/Cxx/ImageData/CMakeLists.txt
@@ -1,18 +1,37 @@
 project (${WIKI}ImageData)
 
-if(NOT WikiExamples_BINARY_DIR)
-find_package(VTK REQUIRED)
-if(NOT VTK_USE_RENDERING)
-  message(FATAL_ERROR "Example ${PROJECT_NAME} requires VTK_USE_RENDERING.")
-endif()
-include(${VTK_USE_FILE})
+if(NOT VTK_BINARY_DIR)
+  set(VTK_LIBRARIES "")
+  find_package(VTK COMPONENTS
+    vtkCommonColor
+    vtkCommonCore
+    vtkCommonDataModel
+    vtkCommonExecutionModel
+    vtkFiltersCore
+    vtkFiltersGeneral
+    vtkFiltersGeometry
+    vtkFiltersSources
+    vtkIOXML
+    vtkImagingCore
+    vtkImagingGeneral
+    vtkImagingMath
+    vtkImagingSources
+    vtkInteractionImage
+    vtkInteractionStyle
+    vtkRenderingCore
+    vtkRenderingFreeType
+    vtkRenderingOpenGL2
+    OPTIONAL_COMPONENTS
+    vtkRenderingGL2PSOpenGL2
+    vtkTestingRendering
+    )
+  if (VTK_VERSION VERSION_LESS "8.90.0")
+    include(${VTK_USE_FILE})
+  endif()
 endif()
 
-if("${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}" LESS 5.8)
-  set(KIT_LIBS vtkFiltering vtkHybrid)
-else()
-  set(KIT_LIBS ${VTK_LIBRARIES})
-endif()
+set(KIT_LIBS ${VTK_LIBRARIES})
+
 #
 # Build all .cxx files in the directory
 file(GLOB ALL_FILES *.cxx)
@@ -21,22 +40,28 @@ foreach(SOURCE_FILE ${ALL_FILES})
   string(REPLACE ${CMAKE_CURRENT_SOURCE_DIR}/ "" EXAMPLE ${TMP})
   add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
   target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
+  if (NOT VTK_VERSION VERSION_LESS "8.90.0")
+    vtk_module_autoinit(
+      TARGETS ${WIKI}${EXAMPLE}
+      MODULES ${VTK_LIBRARIES}
+      )
+  endif()
 endforeach()
 
 if (BUILD_TESTING)
-# Testing
-set(KIT ImageData)
-set(NEEDS_ARGS
-  ExtractVOI
-  ImageNormalize
-)
+  # Testing
+  set(KIT ImageData)
+  set(NEEDS_ARGS
+    ExtractVOI
+    ImageNormalize
+    )
 
-add_test(${KIT}-ExtractVOI ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestExtractVOI -E 50)
+  add_test(${KIT}-ExtractVOI ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestExtractVOI -E 50)
 
-add_test(${KIT}-ImageNormalize ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestImageNormalize -E 35)
+  add_test(${KIT}-ImageNormalize ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestImageNormalize -E 35)
 
-include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
+  include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
 
 endif()

--- a/src/Cxx/ImageProcessing/CMakeLists.txt
+++ b/src/Cxx/ImageProcessing/CMakeLists.txt
@@ -1,8 +1,32 @@
-project (${WIKI}Images)
+project (${WIKI}ImageProcessing)
 
-if(NOT WikiExamples_BINARY_DIR)
-find_package(VTK REQUIRED)
-  include(${VTK_USE_FILE})
+if(NOT VTK_BINARY_DIR)
+  set(VTK_LIBRARIES "")
+  find_package(VTK COMPONENTS
+    vtkCommonColor
+    vtkCommonCore
+    vtkCommonDataModel
+    vtkFiltersGeneral
+    vtkIOImage
+    vtkImagingColor
+    vtkImagingCore
+    vtkImagingFourier
+    vtkImagingGeneral
+    vtkImagingHybrid
+    vtkImagingMath
+    vtkImagingMorphological
+    vtkImagingSources
+    vtkInteractionStyle
+    vtkRenderingCore
+    vtkRenderingFreeType
+    vtkRenderingGL2PSOpenGL2
+    vtkRenderingOpenGL2
+    OPTIONAL_COMPONENTS
+    vtkTestingRendering
+    )
+  if (VTK_VERSION VERSION_LESS "8.90.0")
+    include(${VTK_USE_FILE})
+  endif()
 endif()
 
 set(KIT ImageProcessing)
@@ -17,55 +41,61 @@ foreach(SOURCE_FILE ${ALL_FILES})
   string(REPLACE ${CMAKE_CURRENT_SOURCE_DIR}/ "" EXAMPLE ${TMP})
   add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
   target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
+  if (VTK_VERSION VERSION_GREATER "8.8")
+    vtk_module_autoinit(
+      TARGETS ${WIKI}${EXAMPLE}
+      MODULES ${VTK_LIBRARIES}
+      )
+  endif()
 endforeach()
 
 if (BUILD_TESTING)
-# Testing
-set(NEEDS_ARGS
-  Attenuation
-  EnhanceEdges
-  GaussianSmooth
-  HybridMedianComparison
-  IdealHighPass
-  IsoSubsample
-  MedianComparison
-  MorphologyComparison
-  Pad
-  VTKSpectrum
-)
+  # Testing
+  set(NEEDS_ARGS
+    Attenuation
+    EnhanceEdges
+    GaussianSmooth
+    HybridMedianComparison
+    IdealHighPass
+    IsoSubsample
+    MedianComparison
+    MorphologyComparison
+    Pad
+    VTKSpectrum
+    )
 
-set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
-set(TEMP ${WikiExamples_BINARY_DIR}/Testing/Temporary)
+  set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
+  set(TEMP ${WikiExamples_BINARY_DIR}/Testing/Temporary)
 
-add_test(${KIT}-Attenuation ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestAttenuation ${DATA}/AttenuationArtifact.pgm)
+  add_test(${KIT}-Attenuation ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestAttenuation ${DATA}/AttenuationArtifact.pgm)
 
-add_test(${KIT}-EnhanceEdges ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestEnhanceEdges ${DATA}/FullHead.mhd)
+  add_test(${KIT}-EnhanceEdges ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestEnhanceEdges ${DATA}/FullHead.mhd)
 
-add_test(${KIT}-GaussianSmooth ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestGaussianSmooth ${DATA}/Gourds.png)
+  add_test(${KIT}-GaussianSmooth ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestGaussianSmooth ${DATA}/Gourds.png)
 
-add_test(${KIT}-IdealHighPass ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestIdealHighPass ${DATA}/fullhead15.png)
+  add_test(${KIT}-IdealHighPass ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestIdealHighPass ${DATA}/fullhead15.png)
 
-add_test(${KIT}-HybridMedianComparison ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestHybridMedianComparison ${DATA}/TestPattern.png)
+  add_test(${KIT}-HybridMedianComparison ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestHybridMedianComparison ${DATA}/TestPattern.png)
 
-add_test(${KIT}-MedianComparison ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestMedianComparison ${DATA}/FullHead.mhd)
+  add_test(${KIT}-MedianComparison ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestMedianComparison ${DATA}/FullHead.mhd)
 
-add_test(${KIT}-MorphologyComparison ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestMorphologyComparison ${DATA}/binary.pgm)
+  add_test(${KIT}-MorphologyComparison ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestMorphologyComparison ${DATA}/binary.pgm)
 
-add_test(${KIT}-IsoSubsample ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestIsoSubsample ${DATA}/FullHead.mhd)
+  add_test(${KIT}-IsoSubsample ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestIsoSubsample ${DATA}/FullHead.mhd)
 
-add_test(${KIT}-Pad ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestPad ${DATA}/FullHead.mhd)
+  add_test(${KIT}-Pad ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestPad ${DATA}/FullHead.mhd)
 
-add_test(${KIT}-VTKSpectrum ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestVTKSpectrum ${DATA}/vtks.pgm)
+  add_test(${KIT}-VTKSpectrum ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestVTKSpectrum ${DATA}/vtks.pgm)
 
-include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
+  include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
 endif()

--- a/src/Cxx/Images/CMakeLists.txt
+++ b/src/Cxx/Images/CMakeLists.txt
@@ -1,19 +1,47 @@
 project (${WIKI}Images)
 
-if(NOT WikiExamples_BINARY_DIR)
-find_package(VTK REQUIRED)
-if(NOT VTK_USE_RENDERING)
-  message(FATAL_ERROR "VTKWikiExamples: Example ${PROJECT_NAME} requires VTK_USE_RENDERING.")
-endif()
-include(${VTK_USE_FILE})
+if(NOT VTK_BINARY_DIR)
+  set(VTK_LIBRARIES "")
+  find_package(VTK COMPONENTS
+    vtkCommonColor
+    vtkCommonCore
+    vtkCommonDataModel
+    vtkCommonExecutionModel
+    vtkCommonTransforms
+    vtkFiltersCore
+    vtkFiltersGeneral
+    vtkFiltersGeometry
+    vtkFiltersHybrid
+    vtkFiltersSources
+    vtkIOImage
+    vtkIOXML
+    vtkImagingColor
+    vtkImagingCore
+    vtkImagingFourier
+    vtkImagingGeneral
+    vtkImagingMath
+    vtkImagingMorphological
+    vtkImagingSources
+    vtkImagingStatistics
+    vtkImagingStencil
+    vtkInteractionImage
+    vtkInteractionStyle
+    vtkInteractionWidgets
+    vtkRenderingAnnotation
+    vtkRenderingCore
+    vtkRenderingFreeType
+    vtkRenderingImage
+    vtkRenderingOpenGL2
+    OPTIONAL_COMPONENTS
+    vtkTestingRendering
+    )
+  if (VTK_VERSION VERSION_LESS "8.90.0")
+    include(${VTK_USE_FILE})
+  endif()
 endif()
 
 set(KIT Images)
-if("${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}" LESS 5.8)
-  set(KIT_LIBS vtkHybrid vtkRendering vtkWidgets)
-else()
-  set(KIT_LIBS ${VTK_LIBRARIES})
-endif()
+set(KIT_LIBS ${VTK_LIBRARIES})
 
 #
 # Build all .cxx files in the directory
@@ -22,7 +50,7 @@ file(GLOB ALL_FILES *.cxx)
 if(NOT VTK_USE_SYSTEM_FREETYPE)
   message(STATUS "VTKWikiExamples: ImageText requires VTK_USE_SYSTEM_FREETYPE and will not be built")
   string(REGEX REPLACE "[^;]*ImageText.cxx"
-         "" ALL_FILES "${ALL_FILES}")
+    "" ALL_FILES "${ALL_FILES}")
 endif()
 
 foreach(SOURCE_FILE ${ALL_FILES})
@@ -30,178 +58,184 @@ foreach(SOURCE_FILE ${ALL_FILES})
   string(REPLACE ${CMAKE_CURRENT_SOURCE_DIR}/ "" EXAMPLE ${TMP})
   add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
   target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
+  if (NOT VTK_VERSION VERSION_LESS "8.90.0")
+    vtk_module_autoinit(
+      TARGETS ${WIKI}${EXAMPLE}
+      MODULES ${VTK_LIBRARIES}
+      )
+  endif()
 endforeach()
 
 if (BUILD_TESTING)
-# Testing
-set(NEEDS_ARGS
-#  HistogramBarChart
-#  HistogramXYPlot
-  CannyEdgeDetector
-  Cast
-  CenterAnImage
-  Colored2DImageFusion
-  CombineImages
-  DrawOnAnImage
-  ExtractComponents
-  Flip
-  ImageAccumulateGreyscale
-  ImageAnisotropicDiffusion2D
-  ImageCheckerboard
-  ImageCityBlockDistance
-  ImageContinuousDilate3D
-  ImageContinuousErode3D
-  ImageDilateErode3D
-  ImageHistogram
-  ImageHybridMedian2D
-  ImageMagnify
-  ImageNonMaximumSuppression
-  ImageOpenClose3D
-  ImageRange3D
-  ImageRotate
-  ImageSeparableConvolution
-  ImageToPolyDataFilter
-  ImageToStructuredPoints
-  ImageWarp
-  Transparency
-  InteractWithImage
-  PickPixel
-  PickPixel2
-  RGBToHSI
-  RGBToHSV
-  RGBToYIQ
-  RTAnalyticSource
-  ResizeImage
-  ResizeImageDemo
-  StaticImage
-)
+  # Testing
+  set(NEEDS_ARGS
+    #  HistogramBarChart
+    #  HistogramXYPlot
+    CannyEdgeDetector
+    Cast
+    CenterAnImage
+    Colored2DImageFusion
+    CombineImages
+    DrawOnAnImage
+    ExtractComponents
+    Flip
+    ImageAccumulateGreyscale
+    ImageAnisotropicDiffusion2D
+    ImageCheckerboard
+    ImageCityBlockDistance
+    ImageContinuousDilate3D
+    ImageContinuousErode3D
+    ImageDilateErode3D
+    ImageHistogram
+    ImageHybridMedian2D
+    ImageMagnify
+    ImageNonMaximumSuppression
+    ImageOpenClose3D
+    ImageRange3D
+    ImageRotate
+    ImageSeparableConvolution
+    ImageToPolyDataFilter
+    ImageToStructuredPoints
+    ImageWarp
+    Transparency
+    InteractWithImage
+    PickPixel
+    PickPixel2
+    RGBToHSI
+    RGBToHSV
+    RGBToYIQ
+    RTAnalyticSource
+    ResizeImage
+    ResizeImageDemo
+    StaticImage
+    )
 
-set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
-set(TEMP ${WikiExamples_BINARY_DIR}/Testing/Temporary)
+  set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
+  set(TEMP ${WikiExamples_BINARY_DIR}/Testing/Temporary)
 
-add_test(${KIT}-CannyEdgeDetector ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestCannyEdgeDetector ${DATA}/Gourds.png)
+  add_test(${KIT}-CannyEdgeDetector ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestCannyEdgeDetector ${DATA}/Gourds.png)
 
-add_test(${KIT}-Cast ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestCast  ${DATA}/Ox.jpg ${TEMP}/Cast.jpg)
+  add_test(${KIT}-Cast ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestCast  ${DATA}/Ox.jpg ${TEMP}/Cast.jpg)
 
-add_test(${KIT}-CenterAnImage ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestCenterAnImage  ${DATA}/Ox.jpg)
+  add_test(${KIT}-CenterAnImage ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestCenterAnImage  ${DATA}/Ox.jpg)
 
-add_test(${KIT}-Colored2DImageFusion ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestColored2DImageFusion  ${DATA}/Ox.jpg ${DATA}/Gourds2.jpg)
+  add_test(${KIT}-Colored2DImageFusion ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestColored2DImageFusion  ${DATA}/Ox.jpg ${DATA}/Gourds2.jpg)
 
-add_test(${KIT}-CombineImages ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestCombineImages  ${DATA}/Ox.jpg ${DATA}/Gourds2.jpg)
+  add_test(${KIT}-CombineImages ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestCombineImages  ${DATA}/Ox.jpg ${DATA}/Gourds2.jpg)
 
-add_test(${KIT}-DrawOnAnImage ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestDrawOnAnImage  ${DATA}/Gourds2.jpg)
+  add_test(${KIT}-DrawOnAnImage ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestDrawOnAnImage  ${DATA}/Gourds2.jpg)
 
-add_test(${KIT}-ExtractComponents ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestExtractComponents  ${DATA}/Gourds2.jpg)
+  add_test(${KIT}-ExtractComponents ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestExtractComponents  ${DATA}/Gourds2.jpg)
 
-add_test(${KIT}-Flip ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestFlip  ${DATA}/Gourds2.jpg ${TEMP}/Flip.jpg )
+  add_test(${KIT}-Flip ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestFlip  ${DATA}/Gourds2.jpg ${TEMP}/Flip.jpg )
 
-#add_test(${KIT}-HistogramBarChart ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-#  TestHistogramBarChart ${DATA}/Gourds2.jpg)
+  #add_test(${KIT}-HistogramBarChart ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+  #  TestHistogramBarChart ${DATA}/Gourds2.jpg)
 
-#add_test(${KIT}-HistogramXYPlot ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-#  TestHistogramXYPlot  ${DATA}/Gourds2.jpg)
+  #add_test(${KIT}-HistogramXYPlot ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+  #  TestHistogramXYPlot  ${DATA}/Gourds2.jpg)
 
-add_test(${KIT}-ImageAccumulateGreyscale ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestImageAccumulateGreyscale  ${DATA}/Ox.jpg)
+  add_test(${KIT}-ImageAccumulateGreyscale ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestImageAccumulateGreyscale  ${DATA}/Ox.jpg)
 
-add_test(${KIT}-ImageAnisotropicDiffusion2D ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestImageAnisotropicDiffusion2D  ${DATA}/cake_easy.jpg)
+  add_test(${KIT}-ImageAnisotropicDiffusion2D ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestImageAnisotropicDiffusion2D  ${DATA}/cake_easy.jpg)
 
-add_test(${KIT}-ImageCheckerboard ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestImageCheckerboard  ${DATA}/Ox.jpg ${DATA}/Gourds2.jpg)
+  add_test(${KIT}-ImageCheckerboard ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestImageCheckerboard  ${DATA}/Ox.jpg ${DATA}/Gourds2.jpg)
 
-add_test(${KIT}-ImageCityBlockDistance ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestImageCityBlockDistance ${DATA}/Yinyang.jpg -E 15)
+  add_test(${KIT}-ImageCityBlockDistance ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestImageCityBlockDistance ${DATA}/Yinyang.jpg -E 15)
 
-add_test(${KIT}-ImageContinuousDilate3D ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestImageContinuousDilate3D ${DATA}/Gourds.png)
+  add_test(${KIT}-ImageContinuousDilate3D ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestImageContinuousDilate3D ${DATA}/Gourds.png)
 
-add_test(${KIT}-ImageContinuousErode3D ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestImageContinuousErode3D ${DATA}/Gourds.png)
+  add_test(${KIT}-ImageContinuousErode3D ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestImageContinuousErode3D ${DATA}/Gourds.png)
 
-add_test(${KIT}-ImageDilateErode3D ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestImageDilateErode3D ${DATA}/Yinyang.png -E 25)
+  add_test(${KIT}-ImageDilateErode3D ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestImageDilateErode3D ${DATA}/Yinyang.png -E 25)
 
-add_test(${KIT}-ImageHistogram ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestImageHistogram ${DATA}/Pileated.jpg)
+  add_test(${KIT}-ImageHistogram ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestImageHistogram ${DATA}/Pileated.jpg)
 
-add_test(${KIT}-ImageHybridMedian2D ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestImageHybridMedian2D ${DATA}/Gourds.png)
+  add_test(${KIT}-ImageHybridMedian2D ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestImageHybridMedian2D ${DATA}/Gourds.png)
 
-add_test(${KIT}-ImageMagnify ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestImageMagnify ${DATA}/Gourds.png)
+  add_test(${KIT}-ImageMagnify ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestImageMagnify ${DATA}/Gourds.png)
 
-# The ImageNoiseSource is inherently random
-add_test(${KIT}-ImageNoiseSource ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestImageNoiseSource -E 999999)
+  # The ImageNoiseSource is inherently random
+  add_test(${KIT}-ImageNoiseSource ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestImageNoiseSource -E 999999)
 
-add_test(${KIT}-ImageNonMaximumSuppression ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestImageNonMaximumSuppression -E 20)
+  add_test(${KIT}-ImageNonMaximumSuppression ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestImageNonMaximumSuppression -E 20)
 
-add_test(${KIT}-ImageOpenClose3D ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestImageOpenClose3D ${DATA}/Yinyang.png -E 25)
+  add_test(${KIT}-ImageOpenClose3D ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestImageOpenClose3D ${DATA}/Yinyang.png -E 25)
 
-add_test(${KIT}-InteractWithImage ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestInteractWithImage ${DATA}/Ox.jpg)
+  add_test(${KIT}-InteractWithImage ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestInteractWithImage ${DATA}/Ox.jpg)
 
-add_test(${KIT}-ImageToPolyDataFilter ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestImageToPolyDataFilter ${DATA}/Gourds.png)
+  add_test(${KIT}-ImageToPolyDataFilter ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestImageToPolyDataFilter ${DATA}/Gourds.png)
 
-add_test(${KIT}-ImageRotate ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestImageRotate ${DATA}/Gourds.png 45)
+  add_test(${KIT}-ImageRotate ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestImageRotate ${DATA}/Gourds.png 45)
 
-add_test(${KIT}-ImageSeparableConvolution ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestImageSeparableConvolution ${DATA}/Yinyang.png -E 25)
+  add_test(${KIT}-ImageSeparableConvolution ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestImageSeparableConvolution ${DATA}/Yinyang.png -E 25)
 
-add_test(${KIT}-ImageToStructuredPoints ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestImageToStructuredPoints -E 25)
+  add_test(${KIT}-ImageToStructuredPoints ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestImageToStructuredPoints -E 25)
 
-add_test(${KIT}-ImageWarp ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestImageWarp ${DATA}/masonry.bmp)
+  add_test(${KIT}-ImageWarp ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestImageWarp ${DATA}/masonry.bmp)
 
-add_test(${KIT}-Transparency ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestTransparency  ${DATA}/Ox.jpg)
+  add_test(${KIT}-Transparency ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestTransparency  ${DATA}/Ox.jpg)
 
-add_test(${KIT}-PickPixel ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestPickPixel  ${DATA}/Gourds2.jpg)
+  add_test(${KIT}-PickPixel ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestPickPixel  ${DATA}/Gourds2.jpg)
 
-add_test(${KIT}-PickPixel2 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestPickPixel2  ${DATA}/ColorCells.tif)
+  add_test(${KIT}-PickPixel2 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestPickPixel2  ${DATA}/ColorCells.tif)
 
-add_test(${KIT}-ImageRange3D ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestImageRange3D  ${DATA}/Gourds2.jpg)
+  add_test(${KIT}-ImageRange3D ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestImageRange3D  ${DATA}/Gourds2.jpg)
 
-add_test(${KIT}-RGBToHSI ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestRGBToHSI ${DATA}/Gourds2.jpg)
+  add_test(${KIT}-RGBToHSI ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestRGBToHSI ${DATA}/Gourds2.jpg)
 
-add_test(${KIT}-RGBToHSV ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestRGBToHSV ${DATA}/Gourds2.jpg)
+  add_test(${KIT}-RGBToHSV ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestRGBToHSV ${DATA}/Gourds2.jpg)
 
-add_test(${KIT}-RGBToYIQ ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestRGBToYIQ ${DATA}/Gourds2.jpg)
+  add_test(${KIT}-RGBToYIQ ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestRGBToYIQ ${DATA}/Gourds2.jpg)
 
-add_test(${KIT}-StaticImage ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestStaticImage ${DATA}/Ox.jpg)
+  add_test(${KIT}-StaticImage ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestStaticImage ${DATA}/Ox.jpg)
 
-add_test(${KIT}-Transparency ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestTransparency ${DATA}/Gourds2.jpg)
+  add_test(${KIT}-Transparency ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestTransparency ${DATA}/Gourds2.jpg)
 
-add_test(${KIT}-RTAnalyticSource ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestRTAnalyticSource -E 20)
+  add_test(${KIT}-RTAnalyticSource ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestRTAnalyticSource -E 20)
 
-add_test(${KIT}-ResizeImage ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestResizeImage ${DATA}/Gourds2.jpg 1280 1024 5)
+  add_test(${KIT}-ResizeImage ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestResizeImage ${DATA}/Gourds2.jpg 1280 1024 5)
 
-add_test(${KIT}-ResizeImageDemo ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestResizeImageDemo ${DATA}/Pileated.jpg 3)
+  add_test(${KIT}-ResizeImageDemo ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestResizeImageDemo ${DATA}/Pileated.jpg 3)
 
-include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
+  include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
 endif()

--- a/src/Cxx/ImplicitFunctions/CMakeLists.txt
+++ b/src/Cxx/ImplicitFunctions/CMakeLists.txt
@@ -1,18 +1,34 @@
 project (${WIKI}ImplicitFunctions)
 
-if(NOT WikiExamples_BINARY_DIR)
-find_package(VTK REQUIRED)
-if(NOT VTK_USE_RENDERING)
-  message(FATAL_ERROR "Example ${PROJECT_NAME} requires VTK_USE_RENDERING.")
-endif()
-include(${VTK_USE_FILE})
+if(NOT VTK_BINARY_DIR)
+  set(VTK_LIBRARIES "")
+  find_package(VTK COMPONENTS
+    vtkCommonColor
+    vtkCommonCore
+    vtkCommonDataModel
+    vtkFiltersCore
+    vtkFiltersModeling
+    vtkFiltersSources
+    vtkIOXML
+    vtkImagingCore
+    vtkImagingHybrid
+    vtkInteractionStyle
+    vtkInteractionWidgets
+    vtkRenderingContextOpenGL2
+    vtkRenderingCore
+    vtkRenderingFreeType
+    vtkRenderingGL2PSOpenGL2
+    vtkRenderingOpenGL2
+    OPTIONAL_COMPONENTS
+    vtkTestingRendering
+    )
+  if (VTK_VERSION VERSION_LESS "8.90.0")
+    include(${VTK_USE_FILE})
+  endif()
 endif()
 
-if("${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}" LESS 5.8)
-  set(KIT_LIBS vtkHybrid vtkWidgets)
-else()
-  set(KIT_LIBS ${VTK_LIBRARIES})
-endif()
+set(KIT_LIBS ${VTK_LIBRARIES})
+
 #
 # Build all .cxx files in the directory
 file(GLOB ALL_FILES *.cxx)
@@ -21,17 +37,23 @@ foreach(SOURCE_FILE ${ALL_FILES})
   string(REPLACE ${CMAKE_CURRENT_SOURCE_DIR}/ "" EXAMPLE ${TMP})
   add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
   target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
+  if (NOT VTK_VERSION VERSION_LESS "8.90.0")
+    vtk_module_autoinit(
+      TARGETS ${WIKI}${EXAMPLE}
+      MODULES ${VTK_LIBRARIES}
+      )
+  endif()
 endforeach()
 
 if (BUILD_TESTING)
-# Testing
-set(KIT ImplicitFunctions)
-set(NEEDS_ARGS
+  # Testing
+  set(KIT ImplicitFunctions)
+  set(NEEDS_ARGS
     SampleFunction
-)
+    )
 
-add_test(${KIT}-SampleFunction ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestSampleFunction -E 30)
+  add_test(${KIT}-SampleFunction ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestSampleFunction -E 30)
 
-include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
+  include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
 endif()

--- a/src/Cxx/InfoVis/CMakeLists.txt
+++ b/src/Cxx/InfoVis/CMakeLists.txt
@@ -1,26 +1,42 @@
 project (${WIKI}InfoVis)
 
-if(NOT WikiExamples_BINARY_DIR)
-find_package(VTK REQUIRED)
-if(NOT VTK_USE_INFOVIS)
-  message(FATAL_ERROR "VTKWikiExamples: Example ${PROJECT_NAME} requires VTK_USE_INFOVIS.")
-endif()
-include(${VTK_USE_FILE})
+if(NOT VTK_BINARY_DIR)
+  set(VTK_LIBRARIES "")
+  find_package(VTK COMPONENTS
+    vtkCommonColor
+    vtkCommonComputationalGeometry
+    vtkCommonCore
+    vtkCommonDataModel
+    vtkFiltersGeneral
+    vtkFiltersSources
+    vtkFiltersStatistics
+    vtkIOCore
+    vtkIOInfovis
+    vtkIOXML
+    vtkInfovisCore
+    vtkInfovisLayout
+    vtkInteractionStyle
+    vtkRenderingCore
+    vtkRenderingFreeType
+    vtkRenderingGL2PSOpenGL2
+    vtkRenderingOpenGL2
+    vtkRenderingContextOpenGL2
+    vtkTestingCore
+    vtkTestingRendering
+    vtkViewsCore
+    vtkViewsInfovis
+    )
+  if (VTK_VERSION VERSION_LESS "8.90.0")
+    include(${VTK_USE_FILE})
+  endif()
 endif()
 
-if("${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}" LESS 5.8)
-  set(KIT_LIBS vtkWidgets vtkRendering vtkHybrid vtkViews vtkInfovis)
-else()
-  set(KIT_LIBS ${VTK_LIBRARIES})
-endif()
+set(KIT_LIBS ${VTK_LIBRARIES})
+
 #
 # Build all .cxx files in the directory
 file(GLOB ALL_FILES *.cxx)
 
-include(${WikiExamples_SOURCE_DIR}/CMake/RequiresModule.cmake)
-include(${WikiExamples_SOURCE_DIR}/CMake/RequiresSettingOn.cmake)
-
-include(${WikiExamples_SOURCE_DIR}/CMake/RequiresVersion.cmake)
 set(VERSION_MIN "6.0")
 Requires_Version(TreeMapView ${VERSION_MIN} ALL_FILES)
 Requires_Setting_On (TreeMapView BUILD_TESTING)
@@ -29,7 +45,7 @@ if(NOT VTK_USE_PARALLEL)
   set(SKIP PKMeansClustering)
   message(STATUS "VTKWikiExamples: ${SKIP} requires VTK_PARALLEL and will not be built")
   string(REGEX REPLACE "[^;]*${SKIP}.cxx"
-         "" ALL_FILES "${ALL_FILES}")
+    "" ALL_FILES "${ALL_FILES}")
 endif()
 
 foreach(SOURCE_FILE ${ALL_FILES})
@@ -37,36 +53,42 @@ foreach(SOURCE_FILE ${ALL_FILES})
   string(REPLACE ${CMAKE_CURRENT_SOURCE_DIR}/ "" EXAMPLE ${TMP})
   add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
   target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
+  if (VTK_VERSION VERSION_GREATER "8.8")
+    vtk_module_autoinit(
+      TARGETS ${WIKI}${EXAMPLE}
+      MODULES ${VTK_LIBRARIES}
+      )
+  endif()
 endforeach()
 
 if (BUILD_TESTING)
-# Testing
-set(KIT InfoVis)
+  # Testing
+  set(KIT InfoVis)
 
-set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
+  set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
 
-set(NEEDS_ARGS
-  DelimitedTextReader
-  DelimitedTextWriter
-  XGMLReader
-)
-if ("${ALL_FILES}" MATCHES ".*TreeMapView.*")
-  set(NEEDS_ARGS "${NEEDS_ARGS};TreeMapView")
-  add_test(${KIT}-TreeMapView ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-    TestTreeMapView ${DATA}/Infovis-XML-vtkclasses.xml ${DATA}/Infovis-XML-vtklibrary.xml)
-endif()
+  set(NEEDS_ARGS
+    DelimitedTextReader
+    DelimitedTextWriter
+    XGMLReader
+    )
+  if ("${ALL_FILES}" MATCHES ".*TreeMapView.*")
+    set(NEEDS_ARGS "${NEEDS_ARGS};TreeMapView")
+    add_test(${KIT}-TreeMapView ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+      TestTreeMapView ${DATA}/Infovis-XML-vtkclasses.xml ${DATA}/Infovis-XML-vtklibrary.xml)
+  endif()
 
-set(TEMP ${WikiExamples_BINARY_DIR}/Testing/Temporary)
+  set(TEMP ${WikiExamples_BINARY_DIR}/Testing/Temporary)
 
-add_test(${KIT}-DelimitedTextReader ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestDelimitedTextReader ${DATA}/DelimitedData.txt)
+  add_test(${KIT}-DelimitedTextReader ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestDelimitedTextReader ${DATA}/DelimitedData.txt)
 
-add_test(${KIT}-DelimitedTextWriter ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestDelimitedTextWriter ${TEMP}/foo.txt)
+  add_test(${KIT}-DelimitedTextWriter ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestDelimitedTextWriter ${TEMP}/foo.txt)
 
-add_test(${KIT}-XGMLReader ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestXGMLReader ${DATA}/fsm.gml)
+  add_test(${KIT}-XGMLReader ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestXGMLReader ${DATA}/fsm.gml)
 
-include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
+  include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
 
 endif()

--- a/src/Cxx/Interaction/CMakeLists.txt
+++ b/src/Cxx/Interaction/CMakeLists.txt
@@ -1,18 +1,40 @@
 project (${WIKI}Interaction)
 
-if(NOT WikiExamples_BINARY_DIR)
-find_package(VTK REQUIRED)
-if(NOT VTK_USE_RENDERING)
-  message(FATAL_ERROR "Example ${PROJECT_NAME} requires VTK_USE_RENDERING.")
-endif()
-include(${VTK_USE_FILE})
+if(NOT VTK_BINARY_DIR)
+  set(VTK_LIBRARIES "")
+  find_package(VTK COMPONENTS
+    vtkCommonColor
+    vtkCommonCore
+    vtkCommonDataModel
+    vtkCommonExecutionModel
+    vtkCommonTransforms
+    vtkFiltersCore
+    vtkFiltersExtraction
+    vtkFiltersGeneral
+    vtkFiltersGeometry
+    vtkFiltersModeling
+    vtkFiltersSources
+    vtkIOImage
+    vtkIOXML
+    vtkImagingCore
+    vtkInteractionStyle
+    vtkInteractionWidgets
+    vtkRenderingAnnotation
+    vtkRenderingContextOpenGL2
+    vtkRenderingCore
+    vtkRenderingFreeType
+    vtkRenderingGL2PSOpenGL2
+    vtkRenderingOpenGL2
+    OPTIONAL_COMPONENTS
+    vtkTestingRendering
+    )
+  if (VTK_VERSION VERSION_LESS "8.90.0")
+    include(${VTK_USE_FILE})
+  endif()
 endif()
 
-if("${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}" LESS 5.8)
-  set(KIT_LIBS vtkRendering vtkWidgets vtkHybrid)
-else()
-  set(KIT_LIBS ${VTK_LIBRARIES})
-endif()
+set(KIT_LIBS ${VTK_LIBRARIES})
+
 #
 # Build all .cxx files in the directory
 file(GLOB ALL_FILES *.cxx)
@@ -21,27 +43,33 @@ foreach(SOURCE_FILE ${ALL_FILES})
   string(REPLACE ${CMAKE_CURRENT_SOURCE_DIR}/ "" EXAMPLE ${TMP})
   add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
   target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
+  if (NOT VTK_VERSION VERSION_LESS "8.90.0")
+    vtk_module_autoinit(
+      TARGETS ${WIKI}${EXAMPLE}
+      MODULES ${VTK_LIBRARIES}
+      )
+  endif()
 endforeach()
 
 if (BUILD_TESTING)
-# Testing
-set(KIT Interaction)
-set(NEEDS_ARGS
-  EllipticalButton
-  ImageClip
-  ImageRegion
-)
-set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
+  # Testing
+  set(KIT Interaction)
+  set(NEEDS_ARGS
+    EllipticalButton
+    ImageClip
+    ImageRegion
+    )
+  set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
 
-add_test(${KIT}-EllipticalButton ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestEllipticalButton ${DATA}/Yinyang.png)
+  add_test(${KIT}-EllipticalButton ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestEllipticalButton ${DATA}/Yinyang.png)
 
-add_test(${KIT}-ImageClip ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestImageClip ${DATA}/Gourds2.jpg)
+  add_test(${KIT}-ImageClip ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestImageClip ${DATA}/Gourds2.jpg)
 
-add_test(${KIT}-ImageRegion ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestImageRegion ${DATA}/Gourds2.jpg)
+  add_test(${KIT}-ImageRegion ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestImageRegion ${DATA}/Gourds2.jpg)
 
-include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
+  include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
 
 endif()

--- a/src/Cxx/Lighting/CMakeLists.txt
+++ b/src/Cxx/Lighting/CMakeLists.txt
@@ -1,15 +1,26 @@
 project (${WIKI}Lighting)
 
-if(NOT WikiExamples_BINARY_DIR)
-find_package(VTK REQUIRED)
-include(${VTK_USE_FILE})
+if(NOT VTK_BINARY_DIR)
+  set(VTK_LIBRARIES "")
+  find_package(VTK COMPONENTS
+    vtkCommonColor
+    vtkCommonCore
+    vtkFiltersSources
+    vtkInteractionStyle
+    vtkRenderingCore
+    vtkRenderingFreeType
+    vtkRenderingGL2PSOpenGL2
+    vtkRenderingOpenGL2
+    OPTIONAL_COMPONENTS
+    vtkTestingRendering
+    )
+  if (VTK_VERSION VERSION_LESS "8.90.0")
+    include(${VTK_USE_FILE})
+  endif()
 endif()
 
-if("${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}" LESS 5.8)
-  set(KIT_LIBS vtkHybrid)
-else()
-  set(KIT_LIBS ${VTK_LIBRARIES})
-endif()
+set(KIT_LIBS ${VTK_LIBRARIES})
+
 #
 # Build all .cxx files in the directory
 file(GLOB ALL_FILES *.cxx)
@@ -18,12 +29,18 @@ foreach(SOURCE_FILE ${ALL_FILES})
   string(REPLACE ${CMAKE_CURRENT_SOURCE_DIR}/ "" EXAMPLE ${TMP})
   add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
   target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
+  if (VTK_VERSION VERSION_GREATER "8.8")
+    vtk_module_autoinit(
+      TARGETS ${WIKI}${EXAMPLE}
+      MODULES ${VTK_LIBRARIES}
+      )
+  endif()
 endforeach()
 
 if (BUILD_TESTING)
-# Testing
-set(KIT Lighting)
-set(NEEDS_ARGS
-)
-include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
+  # Testing
+  set(KIT Lighting)
+  set(NEEDS_ARGS
+    )
+  include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
 endif()

--- a/src/Cxx/Math/CMakeLists.txt
+++ b/src/Cxx/Math/CMakeLists.txt
@@ -1,15 +1,28 @@
 project (${WIKI}Math)
 
-if(NOT WikiExamples_BINARY_DIR)
-find_package(VTK REQUIRED)
-include(${VTK_USE_FILE})
+if(NOT VTK_BINARY_DIR)
+  set(VTK_LIBRARIES "")
+  find_package(VTK COMPONENTS
+    vtkCommonComputationalGeometry
+    vtkCommonCore
+    vtkCommonDataModel
+    vtkCommonMath
+    vtkFiltersCore
+    vtkInteractionStyle
+    vtkRenderingContextOpenGL2
+    vtkRenderingCore
+    vtkRenderingFreeType
+    vtkRenderingGL2PSOpenGL2
+    vtkRenderingOpenGL2
+    OPTIONAL_COMPONENTS
+    vtkTestingRendering
+    )
+  if (VTK_VERSION VERSION_LESS "8.90.0")
+    include(${VTK_USE_FILE})
+  endif()
 endif()
 
-if("${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}" LESS 5.8)
-  set(KIT_LIBS vtkHybrid)
-else()
-  set(KIT_LIBS ${VTK_LIBRARIES})
-endif()
+set(KIT_LIBS ${VTK_LIBRARIES})
 #
 # Build all .cxx files in the directory
 file(GLOB ALL_FILES *.cxx)
@@ -18,12 +31,18 @@ foreach(SOURCE_FILE ${ALL_FILES})
   string(REPLACE ${CMAKE_CURRENT_SOURCE_DIR}/ "" EXAMPLE ${TMP})
   add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
   target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
+  if (VTK_VERSION VERSION_GREATER "8.8")
+    vtk_module_autoinit(
+      TARGETS ${WIKI}${EXAMPLE}
+      MODULES ${VTK_LIBRARIES}
+      )
+  endif()
 endforeach()
 
 if (BUILD_TESTING)
-# Testing
-set(KIT Math)
-set(NEEDS_ARGS
-)
-include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
+  # Testing
+  set(KIT Math)
+  set(NEEDS_ARGS
+    )
+  include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
 endif()

--- a/src/Cxx/Medical/CMakeLists.txt
+++ b/src/Cxx/Medical/CMakeLists.txt
@@ -1,8 +1,33 @@
 project (${WIKI}Medical)
 
-if(NOT WikiExamples_BINARY_DIR)
-find_package(VTK REQUIRED)
-include(${VTK_USE_FILE})
+if(NOT VTK_BINARY_DIR)
+  set(VTK_LIBRARIES "")
+  find_package(VTK COMPONENTS
+    vtkCommonColor
+    vtkCommonCore
+    vtkCommonDataModel
+    vtkCommonTransforms
+    vtkFiltersCore
+    vtkFiltersGeneral
+    vtkFiltersGeometry
+    vtkFiltersModeling
+    vtkFiltersSources
+    vtkIOImage
+    vtkIOXML
+    vtkImagingCore
+    vtkImagingStatistics
+    vtkInteractionStyle
+    vtkRenderingCore
+    vtkRenderingFreeType
+    vtkRenderingOpenGL2
+    vtkRenderingVolume
+    vtkRenderingVolumeOpenGL2
+    OPTIONAL_COMPONENTS
+    vtkTestingRendering
+    )
+  if (VTK_VERSION VERSION_LESS "8.90.0")
+    include(${VTK_USE_FILE})
+  endif()
 endif()
 
 set(KIT_LIBS ${VTK_LIBRARIES})
@@ -19,45 +44,51 @@ foreach(SOURCE_FILE ${ALL_FILES})
   string(REPLACE ${CMAKE_CURRENT_SOURCE_DIR}/ "" EXAMPLE ${TMP})
   add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
   target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
+  if (NOT VTK_VERSION VERSION_LESS "8.90.0")
+    vtk_module_autoinit(
+      TARGETS ${WIKI}${EXAMPLE}
+      MODULES ${VTK_LIBRARIES}
+      )
+  endif()
 endforeach()
 
 if (BUILD_TESTING)
-# Testing
-set(KIT Medical)
-set(NEEDS_ARGS
-  GenerateCubesFromLabels
-  GenerateModelsFromLabels
-  MedicalDemo1
-  MedicalDemo2
-  MedicalDemo3
-  MedicalDemo4
-  TissueLens
-)
-set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
+  # Testing
+  set(KIT Medical)
+  set(NEEDS_ARGS
+    GenerateCubesFromLabels
+    GenerateModelsFromLabels
+    MedicalDemo1
+    MedicalDemo2
+    MedicalDemo3
+    MedicalDemo4
+    TissueLens
+    )
+  set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
 
-if(GIT_LFS)
-  add_test(${KIT}-GenerateCubesFromLabels ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-    TestGenerateCubesFromLabels ${DATA}/Frog/frogtissue.mhd 1 29)
+  if(GIT_LFS)
+    add_test(${KIT}-GenerateCubesFromLabels ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+      TestGenerateCubesFromLabels ${DATA}/Frog/frogtissue.mhd 1 29)
 
-  add_test(${KIT}-GenerateModelsFromLabels ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-    TestGenerateModelsFromLabels ${DATA}/Frog/frogtissue.mhd 1 29)
-endif()
+    add_test(${KIT}-GenerateModelsFromLabels ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+      TestGenerateModelsFromLabels ${DATA}/Frog/frogtissue.mhd 1 29)
+  endif()
 
-add_test(${KIT}-MedicalDemo1 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestMedicalDemo1 ${DATA}/FullHead.mhd)
+  add_test(${KIT}-MedicalDemo1 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestMedicalDemo1 ${DATA}/FullHead.mhd)
 
-add_test(${KIT}-MedicalDemo2 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestMedicalDemo2 ${DATA}/FullHead.mhd)
+  add_test(${KIT}-MedicalDemo2 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestMedicalDemo2 ${DATA}/FullHead.mhd)
 
-add_test(${KIT}-MedicalDemo3 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestMedicalDemo3 ${DATA}/FullHead.mhd -E 30)
+  add_test(${KIT}-MedicalDemo3 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestMedicalDemo3 ${DATA}/FullHead.mhd -E 30)
 
-add_test(${KIT}-MedicalDemo4 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestMedicalDemo4 ${DATA}/FullHead.mhd)
+  add_test(${KIT}-MedicalDemo4 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestMedicalDemo4 ${DATA}/FullHead.mhd)
 
-add_test(${KIT}-TissueLens ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestTissueLens ${DATA}/FullHead.mhd)
+  add_test(${KIT}-TissueLens ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestTissueLens ${DATA}/FullHead.mhd)
 
-include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
+  include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
 
 endif()

--- a/src/Cxx/Meshes/CMakeLists.txt
+++ b/src/Cxx/Meshes/CMakeLists.txt
@@ -1,25 +1,45 @@
 project (${WIKI}Meshes)
 
-if(NOT WikiExamples_BINARY_DIR)
-find_package(VTK REQUIRED)
-if(NOT VTK_USE_RENDERING)
-  message(FATAL_ERROR "Example ${PROJECT_NAME} requires VTK_USE_RENDERING.")
-endif()
-include(${VTK_USE_FILE})
+if(NOT VTK_BINARY_DIR)
+  set(VTK_LIBRARIES "")
+  find_package(VTK COMPONENTS
+    vtkCommonColor
+    vtkCommonCore
+    vtkCommonDataModel
+    vtkCommonExecutionModel
+    vtkFiltersCore
+    vtkFiltersExtraction
+    vtkFiltersGeneral
+    vtkFiltersGeometry
+    vtkFiltersModeling
+    vtkFiltersPoints
+    vtkFiltersSources
+    vtkFiltersVerdict
+    vtkIOExodus
+    vtkIOGeometry
+    vtkIOLegacy
+    vtkIOPLY
+    vtkIOXML
+    vtkImagingCore
+    vtkInteractionStyle
+    vtkRenderingContextOpenGL2
+    vtkRenderingCore
+    vtkRenderingFreeType
+    vtkRenderingGL2PSOpenGL2
+    vtkRenderingOpenGL2
+    OPTIONAL_COMPONENTS
+    vtkTestingRendering
+    )
+  if (VTK_VERSION VERSION_LESS "8.90.0")
+    include(${VTK_USE_FILE})
+  endif()
 endif()
 
-if("${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}" LESS 5.8)
-  set(KIT_LIBS vtkRendering vtkHybrid)
-else()
-  set(KIT_LIBS ${VTK_LIBRARIES})
-endif()
+set(KIT_LIBS ${VTK_LIBRARIES})
 
 #
 # Build all .cxx files in the directory
 file(GLOB ALL_FILES *.cxx)
-
-include(${WikiExamples_SOURCE_DIR}/CMake/RequiresVersion.cmake)
-include(${WikiExamples_SOURCE_DIR}/CMake/RequiresModule.cmake)
 
 set(VERSION_MIN "6.0")
 Requires_Version(DeformPointSet ${VERSION_MIN} ALL_FILES)
@@ -29,62 +49,68 @@ foreach(SOURCE_FILE ${ALL_FILES})
   string(REPLACE ${CMAKE_CURRENT_SOURCE_DIR}/ "" EXAMPLE ${TMP})
   add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
   target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
+  if (VTK_VERSION VERSION_GREATER "8.8")
+    vtk_module_autoinit(
+      TARGETS ${WIKI}${EXAMPLE}
+      MODULES ${VTK_LIBRARIES}
+      )
+  endif()
 endforeach()
 
 if (BUILD_TESTING)
-# Testing
-set(KIT Meshes)
-set(NEEDS_ARGS
-  ClipFrustum
-  ClipDataSetWithPolyData
-  Decimation
-  FillHoles
-  IdentifyHoles
-  InterpolateFieldDataDemo
-  MatrixMathFilter
-  OBBDicer
-  QuadricClustering
-  QuadricDecimation
-  SplitPolyData
-  TableBasedClipDataSetWithPolyData
-)
-set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
+  # Testing
+  set(KIT Meshes)
+  set(NEEDS_ARGS
+    ClipFrustum
+    ClipDataSetWithPolyData
+    Decimation
+    FillHoles
+    IdentifyHoles
+    InterpolateFieldDataDemo
+    MatrixMathFilter
+    OBBDicer
+    QuadricClustering
+    QuadricDecimation
+    SplitPolyData
+    TableBasedClipDataSetWithPolyData
+    )
+  set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
 
-add_test(${KIT}-ClipFrustum ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestClipFrustum ${DATA}/Armadillo.ply)
+  add_test(${KIT}-ClipFrustum ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestClipFrustum ${DATA}/Armadillo.ply)
 
-add_test(${KIT}-Decimation ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestDecimation ${DATA}/Torso.vtp)
+  add_test(${KIT}-Decimation ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestDecimation ${DATA}/Torso.vtp)
 
-add_test(${KIT}-QuadricDecimation ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestQuadricDecimation ${DATA}/Torso.vtp)
+  add_test(${KIT}-QuadricDecimation ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestQuadricDecimation ${DATA}/Torso.vtp)
 
-add_test(${KIT}-QuadricClustering ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestQuadricClustering ${DATA}/Torso.vtp)
+  add_test(${KIT}-QuadricClustering ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestQuadricClustering ${DATA}/Torso.vtp)
 
-add_test(${KIT}-ClipDataSetWithPolyData ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestClipDataSetWithPolyData -E 25)
+  add_test(${KIT}-ClipDataSetWithPolyData ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestClipDataSetWithPolyData -E 25)
 
-add_test(${KIT}-FillHoles ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestFillHoles ${DATA}/Torso.vtp)
+  add_test(${KIT}-FillHoles ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestFillHoles ${DATA}/Torso.vtp)
 
-add_test(${KIT}-IdentifyHoles ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestIdentifyHoles ${DATA}/Torso.vtp)
+  add_test(${KIT}-IdentifyHoles ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestIdentifyHoles ${DATA}/Torso.vtp)
 
-add_test(${KIT}-InterpolateFieldDataDemo ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestInterpolateFieldDataDemo ${DATA}/coarseGrid.e ${DATA}/fineGrid.e-s002)
+  add_test(${KIT}-InterpolateFieldDataDemo ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestInterpolateFieldDataDemo ${DATA}/coarseGrid.e ${DATA}/fineGrid.e-s002)
 
-add_test(${KIT}-OBBDicer ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestOBBDicer ${DATA}/Bunny.vtp)
+  add_test(${KIT}-OBBDicer ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestOBBDicer ${DATA}/Bunny.vtp)
 
-add_test(${KIT}-MatrixMathFilter ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestMatrixMathFilter ${DATA}/tensors.vtk)
+  add_test(${KIT}-MatrixMathFilter ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestMatrixMathFilter ${DATA}/tensors.vtk)
 
-add_test(${KIT}-SplitPolyData ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestSplitPolyData ${DATA}/cowHead.vtp)
+  add_test(${KIT}-SplitPolyData ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestSplitPolyData ${DATA}/cowHead.vtp)
 
-add_test(${KIT}-TableBasedClipDataSetWithPolyData ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestTableBasedClipDataSetWithPolyData -E 25)
+  add_test(${KIT}-TableBasedClipDataSetWithPolyData ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestTableBasedClipDataSetWithPolyData -E 25)
 
-include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
+  include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
 endif()

--- a/src/Cxx/Modelling/CMakeLists.txt
+++ b/src/Cxx/Modelling/CMakeLists.txt
@@ -1,8 +1,37 @@
 project (${WIKI}Modelling)
 
-if(NOT WikiExamples_BINARY_DIR)
-find_package(VTK REQUIRED)
-include(${VTK_USE_FILE})
+if(NOT VTK_BINARY_DIR)
+  set(VTK_LIBRARIES "")
+  find_package(VTK COMPONENTS
+    vtkCommonColor
+    vtkCommonCore
+    vtkCommonDataModel
+    vtkFiltersCore
+    vtkFiltersExtraction
+    vtkFiltersGeneral
+    vtkFiltersModeling
+    vtkFiltersSources
+    vtkIOGeometry
+    vtkIOImage
+    vtkIOLegacy
+    vtkIOPLY
+    vtkIOXML
+    vtkImagingCore
+    vtkImagingHybrid
+    vtkImagingMath
+    vtkInteractionStyle
+    vtkInteractionWidgets
+    vtkRenderingCore
+    vtkRenderingFreeType
+    vtkRenderingGL2PSOpenGL2
+    vtkRenderingOpenGL2
+    OPTIONAL_COMPONENTS
+    vtkTestingRendering
+    )
+
+  if (VTK_VERSION VERSION_LESS "8.90.0")
+    include(${VTK_USE_FILE})
+  endif()
 endif()
 
 set(KIT_LIBS ${VTK_LIBRARIES})
@@ -11,8 +40,6 @@ set(KIT_LIBS ${VTK_LIBRARIES})
 # Build all .cxx files in the directory
 file(GLOB ALL_FILES *.cxx)
 
-include(${WikiExamples_SOURCE_DIR}/CMake/RequiresGitLfs.cmake)
-
 Requires_GitLfs(ExtractLargestIsosurface ALL_FILES)
 
 foreach(SOURCE_FILE ${ALL_FILES})
@@ -20,46 +47,52 @@ foreach(SOURCE_FILE ${ALL_FILES})
   string(REPLACE ${CMAKE_CURRENT_SOURCE_DIR}/ "" EXAMPLE ${TMP})
   add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
   target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
+  if (VTK_VERSION VERSION_GREATER "8.8")
+    vtk_module_autoinit(
+      TARGETS ${WIKI}${EXAMPLE}
+      MODULES ${VTK_LIBRARIES}
+      )
+  endif()
 endforeach()
 
 if (BUILD_TESTING)
-# Testing
-set(KIT Modelling)
-set(NEEDS_ARGS
-  ContourTriangulator
-  Delaunay3D
-  Delaunay3DDemo
-  ExtractLargestIsosurface
-  Finance
-  FinanceFieldData
-  MarchingSquares
-)
+  # Testing
+  set(KIT Modelling)
+  set(NEEDS_ARGS
+    ContourTriangulator
+    Delaunay3D
+    Delaunay3DDemo
+    ExtractLargestIsosurface
+    Finance
+    FinanceFieldData
+    MarchingSquares
+    )
 
-set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
-set(TEMP ${WikiExamples_BINARY_DIR}/Testing/Temporary)
+  set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
+  set(TEMP ${WikiExamples_BINARY_DIR}/Testing/Temporary)
 
-add_test(${KIT}-Delaunay3D ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestDelaunay3D ${DATA}/Bunny.vtp)
+  add_test(${KIT}-Delaunay3D ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestDelaunay3D ${DATA}/Bunny.vtp)
 
-add_test(${KIT}-Delaunay3DDemo ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestDelaunay3DDemo ${DATA}/Bunny.vtp)
+  add_test(${KIT}-Delaunay3DDemo ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestDelaunay3DDemo ${DATA}/Bunny.vtp)
 
-add_test(${KIT}-MarchingSquares ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestMarchingSquares ${DATA}/fullhead15.png 500)
+  add_test(${KIT}-MarchingSquares ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestMarchingSquares ${DATA}/fullhead15.png 500)
 
-add_test(${KIT}-Finance ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestFinance ${DATA}/financial.txt)
+  add_test(${KIT}-Finance ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestFinance ${DATA}/financial.txt)
 
-add_test(${KIT}-FinanceFieldData ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestFinanceFieldData ${DATA}/financial.vtk)
+  add_test(${KIT}-FinanceFieldData ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestFinanceFieldData ${DATA}/financial.vtk)
 
-add_test(${KIT}-ContourTriangulator ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestContourTriangulator ${DATA}/fullhead15.png 500)
+  add_test(${KIT}-ContourTriangulator ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestContourTriangulator ${DATA}/fullhead15.png 500)
 
-if(GIT_LFS)
-  add_test(${KIT}-ExtractLargestIsosurface ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-    TestExtractLargestIsosurface ${DATA}/brain.vtk 50 1)
-endif()
+  if(GIT_LFS)
+    add_test(${KIT}-ExtractLargestIsosurface ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+      TestExtractLargestIsosurface ${DATA}/brain.vtk 50 1)
+  endif()
 
-include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
+  include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
 endif()

--- a/src/Cxx/Parallel/CMakeLists.txt
+++ b/src/Cxx/Parallel/CMakeLists.txt
@@ -1,18 +1,22 @@
 project (${WIKI}Parallel)
 
-if(NOT WikiExamples_BINARY_DIR)
-find_package(VTK REQUIRED)
-if(NOT VTK_USE_PARALLEL)
-  message(FATAL_ERROR "Example ${PROJECT_NAME} requires VTK_USE_RENDERING.")
-endif()
-include(${VTK_USE_FILE})
+if(VTK_BINARY_DIR)
+  set(VTK_LIBRARIES "")
+  find_package(VTK COMPONENTS
+    vtkCommonCore
+    vtkCommonDataModel
+    vtkFiltersGeneral
+    vtkIOExodus
+    OPTIONAL_COMPONENTS
+    vtkTestingRendering
+    )
+  if (VTK_VERSION VERSION_LESS "8.90.0")
+    include(${VTK_USE_FILE})
+  endif()
 endif()
 
-if("${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}" LESS 5.8)
-  set(KIT_LIBS vtkHybrid vtkWidgets)
-else()
-  set(KIT_LIBS ${VTK_LIBRARIES})
-endif()
+set(KIT_LIBS ${VTK_LIBRARIES})
+
 #
 # Build all .cxx files in the directory
 file(GLOB ALL_FILES *.cxx)
@@ -21,15 +25,20 @@ foreach(SOURCE_FILE ${ALL_FILES})
   string(REPLACE ${CMAKE_CURRENT_SOURCE_DIR}/ "" EXAMPLE ${TMP})
   add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
   target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
+  if (NOT VTK_VERSION VERSION_LESS "8.90.0")
+    vtk_module_autoinit(
+      TARGETS ${WIKI}${EXAMPLE}
+      MODULES ${VTK_LIBRARIES}
+      )
+  endif()
 endforeach()
 
 # Testing
 set(KIT Parallel)
 set(NEEDS_ARGS
 
-)
+  )
 include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
 
 set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
 set(TEMP ${WikiExamples_BINARY_DIR}/Testing/Temporary)
-

--- a/src/Cxx/Picking/CMakeLists.txt
+++ b/src/Cxx/Picking/CMakeLists.txt
@@ -1,18 +1,33 @@
 project (${WIKI}Picking)
 
-if(NOT WikiExamples_BINARY_DIR)
-find_package(VTK REQUIRED)
-if(NOT VTK_USE_RENDERING)
-  message(FATAL_ERROR "Example ${PROJECT_NAME} requires VTK_USE_RENDERING.")
-endif()
-include(${VTK_USE_FILE})
+if(NOT VTK_BINARY_DIR)
+  set(VTK_LIBRARIES "")
+  find_package(VTK COMPONENTS
+    vtkCommonColor
+    vtkCommonCore
+    vtkCommonDataModel
+    vtkFiltersCore
+    vtkFiltersExtraction
+    vtkFiltersGeneral
+    vtkFiltersGeometry
+    vtkFiltersSources
+    vtkIOXML
+    vtkInteractionStyle
+    vtkRenderingContextOpenGL2
+    vtkRenderingCore
+    vtkRenderingFreeType
+    vtkRenderingGL2PSOpenGL2
+    vtkRenderingOpenGL2
+    OPTIONAL_COMPONENTS
+    vtkTestingRendering
+    )
+  if (VTK_VERSION VERSION_LESS "8.90.0")
+    include(${VTK_USE_FILE})
+  endif()
 endif()
 
-if("${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}" LESS 5.8)
-  set(KIT_LIBS vtkRendering vtkHybrid)
-else()
-  set(KIT_LIBS ${VTK_LIBRARIES})
-endif()
+set(KIT_LIBS ${VTK_LIBRARIES})
+
 #
 # Build all .cxx files in the directory
 file(GLOB ALL_FILES *.cxx)
@@ -21,12 +36,18 @@ foreach(SOURCE_FILE ${ALL_FILES})
   string(REPLACE ${CMAKE_CURRENT_SOURCE_DIR}/ "" EXAMPLE ${TMP})
   add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
   target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
+  if (NOT VTK_VERSION VERSION_LESS "8.90.0")
+    vtk_module_autoinit(
+      TARGETS ${WIKI}${EXAMPLE}
+      MODULES ${VTK_LIBRARIES}
+      )
+  endif()
 endforeach()
 
 if (BUILD_TESTING)
-# Testing
-set(KIT Picking)
-set(NEEDS_ARGS
-)
-include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
+  # Testing
+  set(KIT Picking)
+  set(NEEDS_ARGS
+    )
+  include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
 endif()

--- a/src/Cxx/Plotting/CMakeLists.txt
+++ b/src/Cxx/Plotting/CMakeLists.txt
@@ -1,8 +1,32 @@
 project (${WIKI}Plotting)
 
-if(NOT WikiExamples_BINARY_DIR)
-find_package(VTK REQUIRED)
-include(${VTK_USE_FILE})
+if(NOT VTK_BINARY_DIR)
+  set(VTK_LIBRARIES "")
+  find_package(VTK COMPONENTS
+    vtkChartsCore
+    vtkCommonColor
+    vtkCommonCore
+    vtkCommonDataModel
+    vtkFiltersSources
+    vtkFiltersStatistics
+    vtkIOImage
+    vtkImagingCore
+    vtkImagingStatistics
+    vtkInteractionStyle
+    vtkRenderingAnnotation
+    vtkRenderingContext2D
+    vtkRenderingContextOpenGL2
+    vtkRenderingCore
+    vtkRenderingFreeType
+    vtkRenderingGL2PSOpenGL2
+    vtkRenderingOpenGL2
+    vtkTestingCore
+    vtkTestingRendering
+    vtkViewsContext2D
+    )
+  if (VTK_VERSION VERSION_LESS "8.90.0")
+    include(${VTK_USE_FILE})
+  endif()
 endif()
 
 set(KIT_LIBS ${VTK_LIBRARIES})
@@ -10,8 +34,6 @@ set(KIT_LIBS ${VTK_LIBRARIES})
 #
 # Build all .cxx files in the directory
 file(GLOB ALL_FILES *.cxx)
-
-include(${WikiExamples_SOURCE_DIR}/CMake/RequiresVersion.cmake)
 
 set(VERSION_MIN "7.0")
 Requires_Version(BoxChart ${VERSION_MIN} ALL_FILES)
@@ -23,26 +45,32 @@ foreach(SOURCE_FILE ${ALL_FILES})
   string(REPLACE ${CMAKE_CURRENT_SOURCE_DIR}/ "" EXAMPLE ${TMP})
   add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
   target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
+  if (NOT VTK_VERSION VERSION_LESS "8.90.0")
+    vtk_module_autoinit(
+      TARGETS ${WIKI}${EXAMPLE}
+      MODULES ${VTK_LIBRARIES}
+      )
+  endif()
 endforeach()
 
 if (BUILD_TESTING)
-# Testing
-set(KIT Plotting)
-set(NEEDS_ARGS
-  Diagram
-  HistogramBarChart
-  LinePlot
-)
-set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
+  # Testing
+  set(KIT Plotting)
+  set(NEEDS_ARGS
+    Diagram
+    HistogramBarChart
+    LinePlot
+    )
+  set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
 
-add_test(${KIT}-Diagram ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestDiagram "Brewer Diverging Spectral (8)")
+  add_test(${KIT}-Diagram ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestDiagram "Brewer Diverging Spectral (8)")
 
-add_test(${KIT}-HistogramBarChart ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestHistogramBarChart ${DATA}/Pileated.jpg)
+  add_test(${KIT}-HistogramBarChart ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestHistogramBarChart ${DATA}/Pileated.jpg)
 
-add_test(${KIT}-LinePlot ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestLinePlot -E 50)
+  add_test(${KIT}-LinePlot ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestLinePlot -E 50)
 
-include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
+  include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
 endif()

--- a/src/Cxx/Points/CMakeLists.txt
+++ b/src/Cxx/Points/CMakeLists.txt
@@ -1,25 +1,44 @@
 project (${WIKI}Points)
 
-if(NOT WikiExamples_BINARY_DIR)
-find_package(VTK REQUIRED)
-if(NOT VTK_USE_RENDERING)
-  message(FATAL_ERROR "Example ${PROJECT_NAME} requires VTK_USE_RENDERING.")
-endif()
-include(${VTK_USE_FILE})
+if(NOT VTK_BINARY_DIR)
+  set(optional "")
+  Add_Optional_If_In_Library(Powercrust VTK_LIBRARIES optional)
+  Add_Optional_If_In_Library(PoissonReconstruction VTK_LIBRARIES optional)
+  
+  set(VTK_LIBRARIES "")
+  find_package(VTK COMPONENTS
+    vtkCommonColor
+    vtkCommonCore
+    vtkCommonDataModel
+    vtkCommonSystem
+    vtkFiltersCore
+    vtkFiltersGeneral
+    vtkFiltersPoints
+    vtkFiltersSources
+    vtkIOGeometry
+    vtkIOImage
+    vtkIOPLY
+    vtkIOXML
+    vtkImagingCore
+    vtkInteractionStyle
+    vtkRenderingAnnotation
+    vtkRenderingCore
+    vtkRenderingFreeType
+    vtkRenderingOpenGL2
+    ${optional}
+    OPTIONAL_COMPONENTS
+    vtkTestingRendering
+    )
+  if (VTK_VERSION VERSION_LESS "8.90.0")
+    include(${VTK_USE_FILE})
+  endif()
 endif()
 
-if("${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}" LESS 5.8)
-  set(KIT_LIBS vtkRendering vtkHybrid)
-else()
-  set(KIT_LIBS ${VTK_LIBRARIES})
-endif()
+set(KIT_LIBS ${VTK_LIBRARIES})
 
 #
 # Build all .cxx files in the directory
 file(GLOB ALL_FILES *.cxx)
-
-include(${WikiExamples_SOURCE_DIR}/CMake/RequiresVersion.cmake)
-include(${WikiExamples_SOURCE_DIR}/CMake/RequiresModule.cmake)
 
 set(VERSION_MIN "7.0")
 Requires_Version(DensifyPoints ${VERSION_MIN} ALL_FILES)
@@ -44,45 +63,51 @@ foreach(SOURCE_FILE ${ALL_FILES})
   string(REPLACE ${CMAKE_CURRENT_SOURCE_DIR}/ "" EXAMPLE ${TMP})
   add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
   target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
+  if (NOT VTK_VERSION VERSION_LESS "8.90.0")
+    vtk_module_autoinit(
+      TARGETS ${WIKI}${EXAMPLE}
+      MODULES ${VTK_LIBRARIES}
+      )
+  endif()
 endforeach()
 
 if (BUILD_TESTING)
-# Testing
-set(KIT Points)
-set(NEEDS_ARGS
-  CompareExtractSurface
-  ExtractSurface
-  ExtractSurfaceDemo
-  DensifyPoints
-  MaskPointsFilter
-  PointOccupancy
-  RadiusOutlierRemoval
-  SignedDistance
-  UnsignedDistance
-)
-set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
+  # Testing
+  set(KIT Points)
+  set(NEEDS_ARGS
+    CompareExtractSurface
+    ExtractSurface
+    ExtractSurfaceDemo
+    DensifyPoints
+    MaskPointsFilter
+    PointOccupancy
+    RadiusOutlierRemoval
+    SignedDistance
+    UnsignedDistance
+    )
+  set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
 
-if(Powercrust_LOADED AND PoissonReconstruction_LOADED)
-  add_test(${KIT}-CompareExtractSurface ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-     TestCompareExtractSurface ${DATA}/horsePoints.vtp -E 40)
-endif()
+  if(Powercrust_LOADED AND PoissonReconstruction_LOADED)
+    add_test(${KIT}-CompareExtractSurface ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+      TestCompareExtractSurface ${DATA}/horsePoints.vtp -E 40)
+  endif()
 
-add_test(${KIT}-ExtractSurface ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-     TestExtractSurface ${DATA}/Armadillo.ply)
-add_test(${KIT}-ExtractSurfaceDemo ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-     TestExtractSurfaceDemo ${DATA}/Armadillo.ply)
-add_test(${KIT}-DensifyPoints ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-     TestDensifyPoints ${DATA}/Torso.vtp)
-add_test(${KIT}-MaskPointsFilter ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-     TestMaskPointsFilter ${DATA}/FullHead.mhd)
-add_test(${KIT}-PointOccupancy ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-     TestPointOccupancy ${DATA}/cowHead.vtp)
-add_test(${KIT}-RadiusOutlierRemoval ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-     TestRadiusOutlierRemoval ${DATA}/cowHead.vtp)
-add_test(${KIT}-SignedDistance ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-     TestSignedDistance ${DATA}/Armadillo.ply)
-add_test(${KIT}-UnsignedDistance ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-     TestUnsignedDistance ${DATA}/Armadillo.ply)
+  add_test(${KIT}-ExtractSurface ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestExtractSurface ${DATA}/Armadillo.ply)
+  add_test(${KIT}-ExtractSurfaceDemo ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestExtractSurfaceDemo ${DATA}/Armadillo.ply)
+  add_test(${KIT}-DensifyPoints ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestDensifyPoints ${DATA}/Torso.vtp)
+  add_test(${KIT}-MaskPointsFilter ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestMaskPointsFilter ${DATA}/FullHead.mhd)
+  add_test(${KIT}-PointOccupancy ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestPointOccupancy ${DATA}/cowHead.vtp)
+  add_test(${KIT}-RadiusOutlierRemoval ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestRadiusOutlierRemoval ${DATA}/cowHead.vtp)
+  add_test(${KIT}-SignedDistance ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestSignedDistance ${DATA}/Armadillo.ply)
+  add_test(${KIT}-UnsignedDistance ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestUnsignedDistance ${DATA}/Armadillo.ply)
 
-include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
+  include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
 endif()

--- a/src/Cxx/PolyData/CMakeLists.txt
+++ b/src/Cxx/PolyData/CMakeLists.txt
@@ -1,8 +1,46 @@
 project (${WIKI}PolyData)
 
-if(NOT WikiExamples_BINARY_DIR)
-  find_package(VTK REQUIRED)
-  include(${VTK_USE_FILE})
+if(NOT VTK_BINARY_DIR)
+  set(VTK_LIBRARIES "")
+  find_package(VTK COMPONENTS
+    vtkCommonColor
+    vtkCommonComputationalGeometry
+    vtkCommonCore
+    vtkCommonDataModel
+    vtkCommonExecutionModel
+    vtkCommonTransforms
+    vtkFiltersCore
+    vtkFiltersExtraction
+    vtkFiltersGeneral
+    vtkFiltersGeometry
+    vtkFiltersHybrid
+    vtkFiltersModeling
+    vtkFiltersSources
+    vtkFiltersVerdict
+    vtkIOGeometry
+    vtkIOImage
+    vtkIOLegacy
+    vtkIOPLY
+    vtkIOXML
+    vtkImagingCore
+    vtkImagingHybrid
+    vtkImagingSources
+    vtkImagingStencil
+    vtkInteractionStyle
+    vtkInteractionWidgets
+    vtkRenderingAnnotation
+    vtkRenderingCore
+    vtkRenderingFreeType
+    vtkRenderingGL2PSOpenGL2
+    vtkRenderingLOD
+    vtkRenderingOpenGL2
+    OPTIONAL_COMPONENTS
+    #    vtkFiltersParallelStatistics
+    vtkTestingRendering
+    )
+  if (VTK_VERSION VERSION_LESS "8.90.0")
+    include(${VTK_USE_FILE})
+  endif()
 endif()
 
 set(KIT_LIBS ${VTK_LIBRARIES})
@@ -11,8 +49,6 @@ set(KIT_LIBS ${VTK_LIBRARIES})
 # Build all .cxx files in the directory
 file(GLOB ALL_FILES *.cxx)
 
-include(${WikiExamples_SOURCE_DIR}/CMake/RequiresVersion.cmake)
-
 Requires_Version(Curvatures "6.0.0" ALL_FILES)
 
 foreach(SOURCE_FILE ${ALL_FILES})
@@ -20,134 +56,140 @@ foreach(SOURCE_FILE ${ALL_FILES})
   string(REPLACE ${CMAKE_CURRENT_SOURCE_DIR}/ "" EXAMPLE ${TMP})
   add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
   target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
+  if (VTK_VERSION VERSION_GREATER "8.8")
+    vtk_module_autoinit(
+      TARGETS ${WIKI}${EXAMPLE}
+      MODULES ${VTK_LIBRARIES}
+      )
+  endif()
 endforeach()
 
 if (BUILD_TESTING)
-# Testing
-set(KIT PolyData)
-set(NEEDS_ARGS
-  BooleanOperationPolyDataFilter
-  LoopBooleanPolyDataFilter
-  CellCentersDemo
-  CellLocatorVisualization
-  ColoredPoints
-  ConvexHull
-  Curvatures
-  DetermineArrayDataTypes
-  DijkstraGraphGeodesicPath	
-  EmbedPointsIntoVolume
-  ExternalContour
-  GetMiscCellData
-  GetMiscPointData
-  GradientFilter
-  GreedyTerrainDecimation
-  HighlightBadCells
-  Hull
-  ImplicitModeller
-  MiscPointData
-  PointLocatorVisualization
-  PolyDataIsoLines
-  PolyDataPointSampler
-  PolyDataToImageData
-  RemoveVertices
-  Silhouette
-  ShrinkPolyData
-  ThinPlateSplineTransform
-  TriangleColoredPoints
-  TriangleSolidColor
-  WarpSurface
-)
+  # Testing
+  set(KIT PolyData)
+  set(NEEDS_ARGS
+    BooleanOperationPolyDataFilter
+    LoopBooleanPolyDataFilter
+    CellCentersDemo
+    CellLocatorVisualization
+    ColoredPoints
+    ConvexHull
+    Curvatures
+    DetermineArrayDataTypes
+    DijkstraGraphGeodesicPath	
+    EmbedPointsIntoVolume
+    ExternalContour
+    GetMiscCellData
+    GetMiscPointData
+    GradientFilter
+    GreedyTerrainDecimation
+    HighlightBadCells
+    Hull
+    ImplicitModeller
+    MiscPointData
+    PointLocatorVisualization
+    PolyDataIsoLines
+    PolyDataPointSampler
+    PolyDataToImageData
+    RemoveVertices
+    Silhouette
+    ShrinkPolyData
+    ThinPlateSplineTransform
+    TriangleColoredPoints
+    TriangleSolidColor
+    WarpSurface
+    )
 
-set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
-set(TEMP ${WikiExamples_BINARY_DIR}/Testing/Temporary)
+  set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
+  set(TEMP ${WikiExamples_BINARY_DIR}/Testing/Temporary)
 
-add_test(${KIT}-BooleanOperationPolyDataFilter ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestBooleanOperationPolyDataFilter ${DATA}/Torso.vtp difference ${DATA}/ObliqueCone.vtp)
+  add_test(${KIT}-BooleanOperationPolyDataFilter ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestBooleanOperationPolyDataFilter ${DATA}/Torso.vtp difference ${DATA}/ObliqueCone.vtp)
 
-add_test(${KIT}-LoopBooleanPolyDataFilter ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestLoopBooleanPolyDataFilter ${DATA}/Torso.vtp difference ${DATA}/ObliqueCone.vtp)
+  add_test(${KIT}-LoopBooleanPolyDataFilter ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestLoopBooleanPolyDataFilter ${DATA}/Torso.vtp difference ${DATA}/ObliqueCone.vtp)
 
-add_test(${KIT}-CellCentersDemo ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestCellCentersDemo ${DATA}/cow.g)
+  add_test(${KIT}-CellCentersDemo ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestCellCentersDemo ${DATA}/cow.g)
 
-add_test(${KIT}-CellLocatorVisualization ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestCellLocatorVisualization -E 50)
+  add_test(${KIT}-CellLocatorVisualization ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestCellLocatorVisualization -E 50)
 
-add_test(${KIT}-ColoredPoints ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestColoredPoints ${TEMP}/coloredpoints.vtp)
+  add_test(${KIT}-ColoredPoints ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestColoredPoints ${TEMP}/coloredpoints.vtp)
 
-add_test(${KIT}-ConvexHull ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestConvexHull ${DATA}/cowHead.vtp)
+  add_test(${KIT}-ConvexHull ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestConvexHull ${DATA}/cowHead.vtp)
 
-add_test(${KIT}-Curvatures ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestCurvatures ${DATA}/cowHead.vtp -20 20)
+  add_test(${KIT}-Curvatures ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestCurvatures ${DATA}/cowHead.vtp -20 20)
 
-add_test(${KIT}-DijkstraGraphGeodesicPath ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestDijkstraGraphGeodesicPath	-E 20)
+  add_test(${KIT}-DijkstraGraphGeodesicPath ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestDijkstraGraphGeodesicPath	-E 20)
 
-add_test(${KIT}-EmbedPointsIntoVolume ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestEmbedPointsIntoVolume ${DATA}/Bunny.vtp )
+  add_test(${KIT}-EmbedPointsIntoVolume ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestEmbedPointsIntoVolume ${DATA}/Bunny.vtp )
 
-add_test(${KIT}-ExternalContour ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestExternalContour ${DATA}/Bunny.vtp -E 80 )
+  add_test(${KIT}-ExternalContour ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestExternalContour ${DATA}/Bunny.vtp -E 80 )
 
-add_test(${KIT}-DetermineArrayDataTypes ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestDetermineArrayDataTypes ${DATA}/foilledContours.vtp)
+  add_test(${KIT}-DetermineArrayDataTypes ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestDetermineArrayDataTypes ${DATA}/foilledContours.vtp)
 
-add_test(${KIT}-GetMiscCellData ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestGetMiscCellData ${DATA}/SuperQuadric.vtp Nromals)
+  add_test(${KIT}-GetMiscCellData ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestGetMiscCellData ${DATA}/SuperQuadric.vtp Nromals)
 
-add_test(${KIT}-GetMiscPointData ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestGetMiscPointData ${DATA}/cowHead.vtp Gauss_Curvature)
+  add_test(${KIT}-GetMiscPointData ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestGetMiscPointData ${DATA}/cowHead.vtp Gauss_Curvature)
 
-add_test(${KIT}-GradientFilter ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestGradientFilter ${DATA}/uGridEx.vtk)
+  add_test(${KIT}-GradientFilter ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestGradientFilter ${DATA}/uGridEx.vtk)
 
-add_test(${KIT}-GreedyTerrainDecimation ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestGreedyTerrainDecimation -E 55)
+  add_test(${KIT}-GreedyTerrainDecimation ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestGreedyTerrainDecimation -E 55)
 
-add_test(${KIT}-HighlightBadCells ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestHighlightBadCells -E 20)
+  add_test(${KIT}-HighlightBadCells ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestHighlightBadCells -E 20)
 
-add_test(${KIT}-ImplicitModeller ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestImplicitModeller ${DATA}/Bunny.vtp)
+  add_test(${KIT}-ImplicitModeller ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestImplicitModeller ${DATA}/Bunny.vtp)
 
-add_test(${KIT}-MiscPointData ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestMiscPointData ${DATA}/cowHead.vtp)
+  add_test(${KIT}-MiscPointData ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestMiscPointData ${DATA}/cowHead.vtp)
 
-add_test(${KIT}-PointLocatorVisualization ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestPointLocatorVisualization -E 50)
+  add_test(${KIT}-PointLocatorVisualization ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestPointLocatorVisualization -E 50)
 
-add_test(${KIT}-PolyDataIsoLines ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestPolyDataIsoLines ${DATA}/cowHead.vtp)
+  add_test(${KIT}-PolyDataIsoLines ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestPolyDataIsoLines ${DATA}/cowHead.vtp)
 
-add_test(${KIT}-PolyDataPointSampler ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestPolyDataPointSampler ${DATA}/Torso.vtp)
+  add_test(${KIT}-PolyDataPointSampler ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestPolyDataPointSampler ${DATA}/Torso.vtp)
 
-add_test(${KIT}-PolyDataToImageData ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestPolyDataToImageData ${DATA}/Torso.vtp)
+  add_test(${KIT}-PolyDataToImageData ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestPolyDataToImageData ${DATA}/Torso.vtp)
 
-add_test(${KIT}-RemoveVertices ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestRemoveVertices ${DATA}/Bunny.vtp)
+  add_test(${KIT}-RemoveVertices ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestRemoveVertices ${DATA}/Bunny.vtp)
 
-add_test(${KIT}-Silhouette ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestSilhouette ${DATA}/cowHead.vtp)
+  add_test(${KIT}-Silhouette ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestSilhouette ${DATA}/cowHead.vtp)
 
-add_test(${KIT}-ShrinkPolyData ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestShrinkPolyData ${DATA}/cowHead.vtp -E 30)
+  add_test(${KIT}-ShrinkPolyData ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestShrinkPolyData ${DATA}/cowHead.vtp -E 30)
 
-add_test(${KIT}-ThinPlateSplineTransform ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestThinPlateSplineTransform ${DATA}/masonry.bmp)
+  add_test(${KIT}-ThinPlateSplineTransform ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestThinPlateSplineTransform ${DATA}/masonry.bmp)
 
-add_test(${KIT}-TriangleColoredPoints ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestTriangleColoredPoints -E 15)
+  add_test(${KIT}-TriangleColoredPoints ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestTriangleColoredPoints -E 15)
 
-add_test(${KIT}-TriangleSolidColor ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestTriangleSolidColor -E 25)
+  add_test(${KIT}-TriangleSolidColor ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestTriangleSolidColor -E 25)
 
-add_test(${KIT}-WarpSurface ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestWarpSurface ${DATA}/cowHead.vtp .1)
+  add_test(${KIT}-WarpSurface ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestWarpSurface ${DATA}/cowHead.vtp .1)
 
-include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
+  include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
 
 endif()

--- a/src/Cxx/Qt/CMakeLists.txt
+++ b/src/Cxx/Qt/CMakeLists.txt
@@ -15,19 +15,38 @@ endforeach()
 
 project (QtVTKWikiExamples)
 
-if(NOT WikiExamples_BINARY_DIR)
-find_package(VTK REQUIRED)
-if(NOT VTK_USE_RENDERING)
-  message(FATAL_ERROR "Example ${PROJECT_NAME} requires VTK_USE_RENDERING.")
-endif()
-include(${VTK_USE_FILE})
+if(NOT VTK_BINARY_DIR)
+  set(VTK_LIBRARIES "")
+  find_package(VTK COMPONENTS
+    vtkChartsCore
+    vtkCommonCore
+    vtkCommonDataModel
+    vtkFiltersCore
+    vtkFiltersSources
+    vtkGUISupportQt
+    vtkInfovisCore
+    vtkInteractionStyle
+    vtkInteractionWidgets
+    vtkRenderingContext2D
+    vtkRenderingContextOpenGL2
+    vtkRenderingCore
+    vtkRenderingFreeType
+    vtkRenderingGL2PSOpenGL2
+    vtkRenderingOpenGL2
+    vtkRenderingQt
+    vtkViewsContext2D
+    vtkViewsQt
+    if (VTK_VERSION VERSION_LESS "8.90.0")
+      include(${VTK_USE_FILE})
+    endif()
+
+    )
+  if (VTK_VERSION VERSION_LESS "8.90.0")
+    include(${VTK_USE_FILE})
+  endif()
 endif()
 
-if("${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}" LESS 5.8)
-  set(KIT_LIBS vtkHybrid ${QT_LIBRARIES} )
-else()
-  set(KIT_LIBS ${VTK_LIBRARIES})
-endif()
+set(KIT_LIBS ${VTK_LIBRARIES})
 
 # Let Qt find its MOCed headers in the build directory.
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
@@ -38,8 +57,6 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 # list of all cxx files in the directory - we will build the rest in the next block.
 file(GLOB ALL_UI_FILES *.ui)
 file(GLOB ALL_FILES *.cxx)
-
-include(${WikiExamples_SOURCE_DIR}/CMake/RequiresModule.cmake)
 
 Requires_Module(ShareCameraQt vtkViewsQt)
 Requires_Module(ShareCameraQtDriver vtkViewsQt)
@@ -60,32 +77,52 @@ foreach(EXAMPLE_FILE ${ALL_UI_FILES})
     # CMAKE_AUTOMOC in ON so the MocHdrs will be automatically wrapped.
     add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}Driver.cxx ${EXAMPLE}.cxx ${UISrcs} ${EXAMPLE}.h)
     if (Qt5Widgets_VERSION VERSION_LESS "5.11.0")
-        qt5_use_modules(${WIKI}${EXAMPLE} Core Gui Widgets)
+      qt5_use_modules(${WIKI}${EXAMPLE} Core Gui Widgets)
     else()
-        target_link_libraries(${WIKI}${EXAMPLE} Qt5::Core Qt5::Gui Qt5::Widgets)
-    endif()
-  else()
-    add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
-  endif()
-  target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
-  list(REMOVE_ITEM ALL_FILES ${CMAKE_CURRENT_SOURCE_DIR}/${EXAMPLE}Driver.cxx ${CMAKE_CURRENT_SOURCE_DIR}/${EXAMPLE}.cxx)
-endforeach()
-
-# Build all remaining .cxx files.
-foreach(EXAMPLE_FILE ${ALL_FILES})
-  string(REPLACE ".cxx" "" TMP ${EXAMPLE_FILE})
-  string(REPLACE ${CMAKE_CURRENT_SOURCE_DIR}/ "" EXAMPLE ${TMP})
-
-  if(VTK_QT_VERSION VERSION_GREATER "4")
-    add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
-    if (Qt5Widgets_VERSION VERSION_LESS "5.11.0")
-        qt5_use_modules(${WIKI}${EXAMPLE} Core Gui Widgets)
+      target_link_libraries(${WIKI}${EXAMPLE} Qt5::Core Qt5::Gui Qt5::Widgets)
+      if (VTK_VERSION VERSION_GREATER "8.8")
+        vtk_module_autoinit(
+          TARGETS ${WIKI}${EXAMPLE}
+          MODULES ${VTK_LIBRARIES}
+          )
+      endif()
     else()
-        target_link_libraries(${WIKI}${EXAMPLE} Qt5::Core Qt5::Gui Qt5::Widgets)
+      add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
     endif()
     target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
-  else()
-    add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
-    target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
-  endif()
-endforeach()
+    if (VTK_VERSION VERSION_GREATER "8.8")
+      vtk_module_autoinit(
+        TARGETS ${WIKI}${EXAMPLE}
+        MODULES ${VTK_LIBRARIES}
+        )
+      list(REMOVE_ITEM ALL_FILES ${CMAKE_CURRENT_SOURCE_DIR}/${EXAMPLE}Driver.cxx ${CMAKE_CURRENT_SOURCE_DIR}/${EXAMPLE}.cxx)
+    endforeach()
+
+    # Build all remaining .cxx files.
+    foreach(EXAMPLE_FILE ${ALL_FILES})
+      string(REPLACE ".cxx" "" TMP ${EXAMPLE_FILE})
+      string(REPLACE ${CMAKE_CURRENT_SOURCE_DIR}/ "" EXAMPLE ${TMP})
+
+      if(VTK_QT_VERSION VERSION_GREATER "4")
+        add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
+        if (Qt5Widgets_VERSION VERSION_LESS "5.11.0")
+          qt5_use_modules(${WIKI}${EXAMPLE} Core Gui Widgets)
+        else()
+          target_link_libraries(${WIKI}${EXAMPLE} Qt5::Core Qt5::Gui Qt5::Widgets)
+          if (VTK_VERSION VERSION_GREATER "8.8")
+            vtk_module_autoinit(
+              TARGETS ${WIKI}${EXAMPLE}
+              MODULES ${VTK_LIBRARIES}
+              )
+          endif()
+          target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
+        else()
+          add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
+          target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
+          if (VTK_VERSION VERSION_GREATER "8.8")
+            vtk_module_autoinit(
+              TARGETS ${WIKI}${EXAMPLE}
+              MODULES ${VTK_LIBRARIES}
+              )
+          endif()
+        endforeach()

--- a/src/Cxx/RectilinearGrid/CMakeLists.txt
+++ b/src/Cxx/RectilinearGrid/CMakeLists.txt
@@ -1,18 +1,41 @@
 project (${WIKI}RectilinearGrid)
 
-if(NOT WikiExamples_BINARY_DIR)
-find_package(VTK REQUIRED)
-if(NOT VTK_USE_RENDERING)
-  message(FATAL_ERROR "Example ${PROJECT_NAME} requires VTK_USE_RENDERING.")
-endif()
-include(${VTK_USE_FILE})
+if(NOT VTK_BINARY_DIR)
+  set(VTK_LIBRARIES "")
+  find_package(VTK COMPONENTS
+    vtkCommonColor
+    vtkCommonCore
+    vtkCommonDataModel
+    vtkFiltersGeneral
+    vtkFiltersGeometry
+    vtkIOXML
+    vtkInteractionStyle
+    vtkRenderingCore
+    vtkRenderingFreeType
+    vtkRenderingOpenGL2
+    )
+  find_package(VTK COMPONENTS
+    vtkCommonColor
+    vtkCommonCore
+    vtkCommonDataModel
+    vtkFiltersGeneral
+    vtkFiltersGeometry
+    vtkIOXML
+    vtkInteractionStyle
+    vtkRenderingCore
+    vtkRenderingFreeType
+    vtkRenderingOpenGL2
+    OPTIONAL_COMPONENTS
+    vtkRenderingGL2PSOpenGL2
+    vtkTestingRendering
+    )
+  if (VTK_VERSION VERSION_LESS "8.90.0")
+    include(${VTK_USE_FILE})
+  endif()
 endif()
 
-if("${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}" LESS 5.8)
-  set(KIT_LIBS vtkHybrid)
-else()
-  set(KIT_LIBS ${VTK_LIBRARIES})
-endif()
+set(KIT_LIBS ${VTK_LIBRARIES})
+
 #
 # Build all .cxx files in the directory
 file(GLOB ALL_FILES *.cxx)
@@ -21,10 +44,16 @@ foreach(SOURCE_FILE ${ALL_FILES})
   string(REPLACE ${CMAKE_CURRENT_SOURCE_DIR}/ "" EXAMPLE ${TMP})
   add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
   target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
+  if (NOT VTK_VERSION VERSION_LESS "8.90.0")
+    vtk_module_autoinit(
+      TARGETS ${WIKI}${EXAMPLE}
+      MODULES ${VTK_LIBRARIES}
+      )
+  endif()
 endforeach()
 
 if (BUILD_TESTING)
-# Testing
-set(KIT RectilinearGrid)
-include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
+  # Testing
+  set(KIT RectilinearGrid)
+  include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
 endif()

--- a/src/Cxx/Remote/CMakeLists.txt
+++ b/src/Cxx/Remote/CMakeLists.txt
@@ -1,8 +1,29 @@
 project (${WIKI}Remote)
 
-if(NOT WikiExamples_BINARY_DIR)
-  find_package(VTK REQUIRED)
-  include(${VTK_USE_FILE})
+if(NOT VTK_BINARY_DIR)
+  set(optional "")
+  Add_Optional_If_In_Library(SplineDrivenImageSlicer VTK_LIBRARIES optional)
+  set(VTK_LIBRARIES "")
+  find_package(VTK COMPONENTS
+    vtkCommonComputationalGeometry
+    vtkCommonCore
+    vtkCommonDataModel
+    vtkFiltersCore
+    vtkFiltersSources
+    vtkInteractionStyle
+    vtkInteractionWidgets
+    vtkRenderingContextOpenGL2
+    vtkRenderingCore
+    vtkRenderingFreeType
+    vtkRenderingGL2PSOpenGL2
+    vtkRenderingOpenGL2
+    ${optional}
+    OPTIONAL_COMPONENTS
+    vtkTestingRendering
+    )
+  if (VTK_VERSION VERSION_LESS "8.90.0")
+    include(${VTK_USE_FILE})
+  endif()
 endif()
 
 set(KIT_LIBS ${VTK_LIBRARIES})
@@ -10,8 +31,6 @@ set(KIT_LIBS ${VTK_LIBRARIES})
 #
 # Build all .cxx files in the directory
 file(GLOB ALL_FILES *.cxx)
-
-include(${WikiExamples_SOURCE_DIR}/CMake/RequiresModule.cmake)
 
 Requires_Module(FrenetSerretFrame SplineDrivenImageSlicer)
 Requires_Module(FrenetSerretFrameDemo SplineDrivenImageSlicer)
@@ -21,12 +40,18 @@ foreach(SOURCE_FILE ${ALL_FILES})
   string(REPLACE ${CMAKE_CURRENT_SOURCE_DIR}/ "" EXAMPLE ${TMP})
   add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
   target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
+  if (VTK_VERSION VERSION_GREATER "8.8")
+    vtk_module_autoinit(
+      TARGETS ${WIKI}${EXAMPLE}
+      MODULES ${VTK_LIBRARIES}
+      )
+  endif()
 endforeach()
 
 if (BUILD_TESTING)
-# Testing
-set(KIT Remote)
-set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
+  # Testing
+  set(KIT Remote)
+  set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
 
-include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
+  include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
 endif()

--- a/src/Cxx/RenderMan/CMakeLists.txt
+++ b/src/Cxx/RenderMan/CMakeLists.txt
@@ -1,19 +1,37 @@
 project (${WIKI}RenderMan)
 
-if(NOT WikiExamples_BINARY_DIR)
-find_package(VTK REQUIRED)
-include(${VTK_USE_FILE})
+if(NOT VTK_BINARY_DIR)
+  set(VTK_LIBRARIES "")
+  if (VTK_VERSION VERSION_LESS "8.90.0")
+    set(components "vtkIOExportOpenGL2")
+  endif()
+
+  set(VTK_LIBRARIES "")
+  find_package(VTK COMPONENTS
+    vtkCommonCore
+    vtkFiltersCore
+    vtkIOExport
+    vtkIOExportPDF
+    vtkIOXML
+    vtkInteractionStyle
+    vtkRenderingContextOpenGL2
+    vtkRenderingCore
+    vtkRenderingFreeType
+    ${components}
+    vtkRenderingOpenGL2
+    OPTIONAL_COMPONENTS
+    vtkTestingRendering
+    )
+  if (VTK_VERSION VERSION_LESS "8.90.0")
+    include(${VTK_USE_FILE})
+  endif()
 endif()
 
-if("${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}" LESS 5.8)
-  set(KIT_LIBS vtkRendering vtkHybrid)
-else()
-  set(KIT_LIBS ${VTK_LIBRARIES})
-endif()
+set(KIT_LIBS ${VTK_LIBRARIES})
+
 #
 # Build all .cxx files in the directory
 file(GLOB ALL_FILES *.cxx)
-include(${WikiExamples_SOURCE_DIR}/CMake/RequiresVersion.cmake)
 
 set(VERSION_MIN "6.0")
 Requires_Version(PolyDataRIB ${VERSION_MIN} ALL_FILES)
@@ -21,19 +39,25 @@ Requires_Version(PolyDataRIB ${VERSION_MIN} ALL_FILES)
 foreach(SOURCE_FILE ${ALL_FILES})
   string(REPLACE ".cxx" "" TMP ${SOURCE_FILE})
   string(REPLACE ${CMAKE_CURRENT_SOURCE_DIR}/ "" EXAMPLE ${TMP})
-  add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
-  target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
+  add_executable(${WIKI}${EXAMPLE}${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
+  target_link_libraries(${WIKI}${EXAMPLE} PRIVATE ${KIT_LIBS})
+  if (NOT VTK_VERSION VERSION_LESS "8.90.0")
+    vtk_module_autoinit(
+      TARGETS ${WIKI}${EXAMPLE}
+      MODULES ${VTK_LIBRARIES}
+      )
+  endif()
 endforeach()
 
 if (BUILD_TESTING)
-# Testing
-set(KIT RenderMan)
-set(NEEDS_ARGS
-  PolyDataRIB
-)
-set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
-add_test(${KIT}-PolyDataRIB ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestPolyDataRIB ${DATA}/Torso.vtp .01)
+  # Testing
+  set(KIT RenderMan)
+  set(NEEDS_ARGS
+    PolyDataRIB
+    )
+  set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
+  add_test(${KIT}-PolyDataRIB ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestPolyDataRIB ${DATA}/Torso.vtp .01)
 
-include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
+  include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
 endif()

--- a/src/Cxx/Rendering/CMakeLists.txt
+++ b/src/Cxx/Rendering/CMakeLists.txt
@@ -1,8 +1,35 @@
 project (${WIKI}Rendering)
 
-if(NOT WikiExamples_BINARY_DIR)
-  find_package(VTK REQUIRED)
-  include(${VTK_USE_FILE})
+if(NOT VTK_BINARY_DIR)
+  set(VTK_LIBRARIES "")
+  find_package(VTK COMPONENTS
+    vtkCommonColor
+    vtkCommonCore
+    vtkCommonDataModel
+    vtkCommonTransforms
+    vtkFiltersCore
+    vtkFiltersGeneral
+    vtkFiltersGeometry
+    vtkFiltersSources
+    vtkIOGeometry
+    vtkIOImage
+    vtkIOLegacy
+    vtkIOPLY
+    vtkIOParallel
+    vtkIOXML
+    vtkImagingHybrid
+    vtkInteractionStyle
+    vtkRenderingContextOpenGL2
+    vtkRenderingCore
+    vtkRenderingFreeType
+    vtkRenderingGL2PSOpenGL2
+    vtkRenderingOpenGL2
+    OPTIONAL_COMPONENTS
+    vtkTestingRendering
+    )
+  if (VTK_VERSION VERSION_LESS "8.90.0")
+    include(${VTK_USE_FILE})
+  endif()
 endif()
 
 set(KIT_LIBS ${VTK_LIBRARIES})
@@ -15,64 +42,70 @@ foreach(SOURCE_FILE ${ALL_FILES})
   string(REPLACE ${CMAKE_CURRENT_SOURCE_DIR}/ "" EXAMPLE ${TMP})
   add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
   target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
+  if (VTK_VERSION VERSION_GREATER "8.8")
+    vtk_module_autoinit(
+      TARGETS ${WIKI}${EXAMPLE}
+      MODULES ${VTK_LIBRARIES}
+      )
+  endif()
 endforeach()
 
 if (BUILD_TESTING)
-# Testing
-set(KIT Rendering)
-set(NEEDS_ARGS
-  FlatVersusGouraud
-  MotionBlur
-  Rainbow
-  Rotations
-  RotationsA
-  RotationsB
-  RotationsC
-  RotationsD
-  StripFran
-  WalkCow
-  WalkCowA
-  WalkCowB
-)
-set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
-set(TEMP ${WikiExamples_BINARY_DIR}/Testing/Temporary)
+  # Testing
+  set(KIT Rendering)
+  set(NEEDS_ARGS
+    FlatVersusGouraud
+    MotionBlur
+    Rainbow
+    Rotations
+    RotationsA
+    RotationsB
+    RotationsC
+    RotationsD
+    StripFran
+    WalkCow
+    WalkCowA
+    WalkCowB
+    )
+  set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
+  set(TEMP ${WikiExamples_BINARY_DIR}/Testing/Temporary)
 
-add_test(${KIT}-FlatVersusGouraud ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestFlatVersusGouraud ${DATA}/cow.obj)
+  add_test(${KIT}-FlatVersusGouraud ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestFlatVersusGouraud ${DATA}/cow.obj)
 
-add_test(${KIT}-MotionBlur ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestMotionBlur ${DATA}/Armadillo.ply)
+  add_test(${KIT}-MotionBlur ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestMotionBlur ${DATA}/Armadillo.ply)
 
-add_test(${KIT}-Rotations ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestRotations ${DATA}/cow.obj)
+  add_test(${KIT}-Rotations ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestRotations ${DATA}/cow.obj)
 
-add_test(${KIT}-RotationsA ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestRotationsA ${DATA}/cow.obj 1 1)
+  add_test(${KIT}-RotationsA ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestRotationsA ${DATA}/cow.obj 1 1)
 
-add_test(${KIT}-RotationsB ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestRotationsB ${DATA}/cow.obj 2 1)
+  add_test(${KIT}-RotationsB ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestRotationsB ${DATA}/cow.obj 2 1)
 
-add_test(${KIT}-RotationsC ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestRotationsC ${DATA}/cow.obj 3 1)
+  add_test(${KIT}-RotationsC ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestRotationsC ${DATA}/cow.obj 3 1)
 
-add_test(${KIT}-RotationsD ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestRotationsD ${DATA}/cow.obj 4 1)
+  add_test(${KIT}-RotationsD ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestRotationsD ${DATA}/cow.obj 4 1)
 
-add_test(${KIT}-Rainbow ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestRainbow ${DATA}/combxyz.bin ${DATA}/combq.bin)
+  add_test(${KIT}-Rainbow ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestRainbow ${DATA}/combxyz.bin ${DATA}/combq.bin)
 
-add_test(${KIT}-StripFran ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestStripFran ${DATA}/fran_cut.vtk)
+  add_test(${KIT}-StripFran ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestStripFran ${DATA}/fran_cut.vtk)
 
-add_test(${KIT}-WalkCow ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestWalkCow ${DATA}/cow.g)
+  add_test(${KIT}-WalkCow ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestWalkCow ${DATA}/cow.g)
 
-add_test(${KIT}-WalkCowA ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestWalkCowA ${DATA}/cow.g 1)
+  add_test(${KIT}-WalkCowA ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestWalkCowA ${DATA}/cow.g 1)
 
-add_test(${KIT}-WalkCowB ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestWalkCowB ${DATA}/cow.g 2)
+  add_test(${KIT}-WalkCowB ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestWalkCowB ${DATA}/cow.g 2)
 
-include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
+  include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
 
 endif()

--- a/src/Cxx/Shaders/CMakeLists.txt
+++ b/src/Cxx/Shaders/CMakeLists.txt
@@ -1,8 +1,33 @@
 project (${WIKI}Shaders)
 
-if(NOT WikiExamples_BINARY_DIR)
-find_package(VTK REQUIRED)
-  include(${VTK_USE_FILE})
+if(NOT VTK_BINARY_DIR)
+  set(VTK_LIBRARIES "")
+  find_package(VTK COMPONENTS
+    vtkCommonColor
+    vtkCommonCore
+    vtkCommonDataModel
+    vtkCommonTransforms
+    vtkFiltersCore
+    vtkFiltersGeneral
+    vtkFiltersSources
+    vtkIOGeometry
+    vtkIOImage
+    vtkIOLegacy
+    vtkIOPLY
+    vtkIOXML
+    vtkImagingCore
+    vtkInteractionStyle
+    vtkInteractionWidgets
+    vtkRenderingCore
+    vtkRenderingFreeType
+    vtkRenderingOpenGL2
+    vtkRenderingGL2PSOpenGL2
+    OPTIONAL_COMPONENTS
+    vtkTestingRendering
+    )
+  if (VTK_VERSION VERSION_LESS "8.90.0")
+    include(${VTK_USE_FILE})
+  endif()
 endif()
 
 set(KIT_LIBS ${VTK_LIBRARIES})
@@ -14,55 +39,63 @@ foreach(SOURCE_FILE ${ALL_FILES})
   string(REPLACE ${CMAKE_CURRENT_SOURCE_DIR}/ "" EXAMPLE ${TMP})
   add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
   target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
+  if (NOT VTK_VERSION VERSION_LESS "8.90.0")
+    vtk_module_autoinit(
+      TARGETS ${WIKI}${EXAMPLE}
+      MODULES ${VTK_LIBRARIES}
+      )
+  endif()
 endforeach()
 
-# Testing
-set(KIT Shaders)
-set(NEEDS_ARGS
-  BozoShader
-  BozoShaderDemo
-  ColorByNormal
-  CubeMap
-  MarbleShader
-  MarbleShaderDemo
-  SpatterShader
-  SphereMap
-)
+if (BUILD_TESTING)
+  # Testing
+  set(KIT Shaders)
+  set(NEEDS_ARGS
+    BozoShader
+    BozoShaderDemo
+    ColorByNormal
+    CubeMap
+    MarbleShader
+    MarbleShaderDemo
+    SpatterShader
+    SphereMap
+    )
 
-set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
+  set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
 
-add_test(${KIT}-BozoShader ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestBozoShader ${DATA}/Shaders/PerlinNoise.glsl ${DATA}/horse.ply)
+  add_test(${KIT}-BozoShader ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestBozoShader ${DATA}/Shaders/PerlinNoise.glsl ${DATA}/horse.ply)
 
-add_test(${KIT}-BozoShaderDemo ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestBozoShaderDemo ${DATA}/Shaders/PerlinNoise.glsl
-  ${DATA}/horse.ply
-  ${DATA}/teapot.g
-  ${DATA}/trumpet.obj
-  ${DATA}/shark.ply
-  ${DATA}/Torso.vtp
-  ${DATA}/cow.g
-  ${DATA}/Armadillo.ply
-  ${DATA}/42400-IDGH.stl
-  ${DATA}/doorman/doorman.obj )
+  add_test(${KIT}-BozoShaderDemo ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestBozoShaderDemo ${DATA}/Shaders/PerlinNoise.glsl
+    ${DATA}/horse.ply
+    ${DATA}/teapot.g
+    ${DATA}/trumpet.obj
+    ${DATA}/shark.ply
+    ${DATA}/Torso.vtp
+    ${DATA}/cow.g
+    ${DATA}/Armadillo.ply
+    ${DATA}/42400-IDGH.stl
+    ${DATA}/doorman/doorman.obj )
 
-add_test(${KIT}-ColorByNormal ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestColorByNormal ${DATA}/Armadillo.ply)
+  add_test(${KIT}-ColorByNormal ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestColorByNormal ${DATA}/Armadillo.ply)
 
-add_test(${KIT}-CubeMap ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestCubeMap ${DATA}/horse.ply ${DATA}/skybox-px.jpg ${DATA}/skybox-nx.jpg ${DATA}/skybox-py.jpg ${DATA}/skybox-ny.jpg ${DATA}/skybox-pz.jpg ${DATA}/skybox-nz.jpg)
+  add_test(${KIT}-CubeMap ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestCubeMap ${DATA}/horse.ply ${DATA}/skybox-px.jpg ${DATA}/skybox-nx.jpg ${DATA}/skybox-py.jpg ${DATA}/skybox-ny.jpg ${DATA}/skybox-pz.jpg ${DATA}/skybox-nz.jpg)
 
-add_test(${KIT}-MarbleShader ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestMarbleShader ${DATA}/Shaders/PerlinNoise.glsl ${DATA}/horse.ply)
+  add_test(${KIT}-MarbleShader ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestMarbleShader ${DATA}/Shaders/PerlinNoise.glsl ${DATA}/horse.ply)
 
-add_test(${KIT}-MarbleShaderDemo ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestMarbleShaderDemo ${DATA}/Shaders/PerlinNoise.glsl ${DATA}/teapot.g)
+  add_test(${KIT}-MarbleShaderDemo ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestMarbleShaderDemo ${DATA}/Shaders/PerlinNoise.glsl ${DATA}/teapot.g)
 
-add_test(${KIT}-SpatterShader ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestSpatterShader ${DATA}/Shaders/PerlinNoise.glsl ${DATA}/horse.ply)
+  add_test(${KIT}-SpatterShader ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestSpatterShader ${DATA}/Shaders/PerlinNoise.glsl ${DATA}/horse.ply)
 
-add_test(${KIT}-SphereMap ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestSphereMap ${DATA}/Bunny.vtp ${DATA}/wintersun.jpg)
+  add_test(${KIT}-SphereMap ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestSphereMap ${DATA}/Bunny.vtp ${DATA}/wintersun.jpg)
 
 
-include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
+  include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
+endif()

--- a/src/Cxx/SimpleOperations/CMakeLists.txt
+++ b/src/Cxx/SimpleOperations/CMakeLists.txt
@@ -1,18 +1,20 @@
 project (${WIKI}SimpleOperations)
 
 if(NOT WikiExamples_BINARY_DIR)
-find_package(VTK REQUIRED)
-if(NOT VTK_USE_RENDERING)
-  message(FATAL_ERROR "Example ${PROJECT_NAME} requires VTK_USE_RENDERING.")
-endif()
-include(${VTK_USE_FILE})
+  set(VTK_LIBRARIES "")
+  find_package(VTK COMPONENTS
+    vtkCommonCore
+    vtkCommonDataModel
+    vtkCommonMath
+    vtkCommonTransforms
+    )
+  if (VTK_VERSION VERSION_LESS "8.90.0")
+    include(${VTK_USE_FILE})
+  endif()
 endif()
 
-if("${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}" LESS 5.8)
-  set(KIT_LIBS vtkRendering vtkHybrid)
-else()
-  set(KIT_LIBS ${VTK_LIBRARIES})
-endif()
+set(KIT_LIBS ${VTK_LIBRARIES})
+
 #
 # Build all .cxx files in the directory
 file(GLOB ALL_FILES *.cxx)
@@ -21,20 +23,26 @@ foreach(SOURCE_FILE ${ALL_FILES})
   string(REPLACE ${CMAKE_CURRENT_SOURCE_DIR}/ "" EXAMPLE ${TMP})
   add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
   target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
+  if (VTK_VERSION VERSION_GREATER "8.8")
+    vtk_module_autoinit(
+      TARGETS ${WIKI}${EXAMPLE}
+      MODULES ${VTK_LIBRARIES}
+      )
+  endif()
 endforeach()
 
 if (BUILD_TESTING)
 
-# Testing
-set(KIT SimpleOperations)
+  # Testing
+  set(KIT SimpleOperations)
 
-set (EXCLUDE_TEST
-  FloatingPointExceptions
-)
+  set (EXCLUDE_TEST
+    FloatingPointExceptions
+    )
 
-include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
-# set_tests_properties(
-#     SimpleOperations-FloatingPointExceptions
-#     PROPERTIES WILL_FAIL TRUE
-#     )
+  include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
+  # set_tests_properties(
+  #     SimpleOperations-FloatingPointExceptions
+  #     PROPERTIES WILL_FAIL TRUE
+  #     )
 endif()

--- a/src/Cxx/StructuredGrid/CMakeLists.txt
+++ b/src/Cxx/StructuredGrid/CMakeLists.txt
@@ -1,18 +1,31 @@
 project (${WIKI}StructuredGrid)
 
-if(NOT WikiExamples_BINARY_DIR)
-find_package(VTK REQUIRED)
-if(NOT VTK_USE_RENDERING)
-  message(FATAL_ERROR "Example ${PROJECT_NAME} requires VTK_USE_RENDERING.")
-endif()
-include(${VTK_USE_FILE})
+if(NOT VTK_BINARY_DIR)
+  set(VTK_LIBRARIES "")
+  find_package(VTK COMPONENTS
+    vtkCommonColor
+    vtkCommonCore
+    vtkCommonDataModel
+    vtkFiltersCore
+    vtkFiltersGeneral
+    vtkFiltersGeometry
+    vtkIOXML
+    vtkInteractionStyle
+    vtkRenderingCore
+    vtkRenderingFreeType
+    vtkRenderingOpenGL2
+    OPTIONAL_COMPONENTS
+    vtkRenderingGL2PSOpenGL2
+    vtkTestingRendering
+    )
+  if (VTK_VERSION VERSION_LESS "8.90.0")
+    include(${VTK_USE_FILE})
+  endif()
+
 endif()
 
-if("${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}" LESS 5.8)
-  set(KIT_LIBS vtkHybrid)
-else()
-  set(KIT_LIBS ${VTK_LIBRARIES})
-endif()
+set(KIT_LIBS ${VTK_LIBRARIES})
+
 #
 # Build all .cxx files in the directory
 file(GLOB ALL_FILES *.cxx)
@@ -21,12 +34,18 @@ foreach(SOURCE_FILE ${ALL_FILES})
   string(REPLACE ${CMAKE_CURRENT_SOURCE_DIR}/ "" EXAMPLE ${TMP})
   add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
   target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
+  if (NOT VTK_VERSION VERSION_LESS "8.90.0")
+    vtk_module_autoinit(
+      TARGETS ${WIKI}${EXAMPLE}
+      MODULES ${VTK_LIBRARIES}
+      )
+  endif()
 endforeach()
 
 if (BUILD_TESTING)
-# Testing
-set(KIT StructuredGrid)
-set(NEEDS_ARGS
-)
-include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
+  # Testing
+  set(KIT StructuredGrid)
+  set(NEEDS_ARGS
+    )
+  include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
 endif()

--- a/src/Cxx/StructuredPoints/CMakeLists.txt
+++ b/src/Cxx/StructuredPoints/CMakeLists.txt
@@ -1,11 +1,23 @@
 project (${WIKI}StructuredPoints)
 
-if(NOT WikiExamples_BINARY_DIR)
-find_package(VTK REQUIRED)
-if(NOT VTK_USE_RENDERING)
-  message(FATAL_ERROR "Example ${PROJECT_NAME} requires VTK_USE_RENDERING.")
-endif()
-include(${VTK_USE_FILE})
+if(NOT VTK_BINARY_DIR)
+  set(VTK_LIBRARIES "")
+  find_package(VTK COMPONENTS
+    vtkCommonColor
+    vtkCommonCore
+    vtkCommonDataModel
+    vtkFiltersCore
+    vtkIOXML
+    vtkInteractionStyle
+    vtkRenderingCore
+    vtkRenderingFreeType
+    vtkRenderingOpenGL2
+    OPTIONAL_COMPONENTS
+    vtkTestingRendering
+    )
+  if (VTK_VERSION VERSION_LESS "8.90.0")
+    include(${VTK_USE_FILE})
+  endif()
 endif()
 
 set(KIT_LIBS ${VTK_LIBRARIES})
@@ -13,20 +25,25 @@ set(KIT_LIBS ${VTK_LIBRARIES})
 # Build all .cxx files in the directory
 file(GLOB ALL_FILES *.cxx)
 
-include(${WikiExamples_SOURCE_DIR}/CMake/RequiresVersion.cmake)
 foreach(SOURCE_FILE ${ALL_FILES})
   string(REPLACE ".cxx" "" TMP ${SOURCE_FILE})
   string(REPLACE ${CMAKE_CURRENT_SOURCE_DIR}/ "" EXAMPLE ${TMP})
   add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
   target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
+  if (VTK_VERSION VERSION_GREATER "8.8")
+    vtk_module_autoinit(
+      TARGETS ${WIKI}${EXAMPLE}
+      MODULES ${VTK_LIBRARIES}
+      )
+  endif()
 endforeach()
 
 if (BUILD_TESTING)
-# Testing
-set(KIT StructuredPoints)
-set(NEEDS_ARGS
-)
-set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
-set(TEMP ${WikiExamples_BINARY_DIR}/Testing/Temporary)
-include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
+  # Testing
+  set(KIT StructuredPoints)
+  set(NEEDS_ARGS
+    )
+  set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
+  set(TEMP ${WikiExamples_BINARY_DIR}/Testing/Temporary)
+  include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
 endif()

--- a/src/Cxx/Texture/CMakeLists.txt
+++ b/src/Cxx/Texture/CMakeLists.txt
@@ -1,8 +1,58 @@
 project (${WIKI}Texture)
 
-if(NOT WikiExamples_BINARY_DIR)
-find_package(VTK REQUIRED)
-  include(${VTK_USE_FILE})
+if(NOT VTK_BINARY_DIR)
+  set(VTK_LIBRARIES "")
+  find_package(VTK COMPONENTS
+    vtkCommonColor
+    vtkCommonCore
+    vtkCommonDataModel
+    vtkFiltersCore
+    vtkFiltersGeometry
+    vtkFiltersModeling
+    vtkFiltersSources
+    vtkFiltersTexture
+    vtkIOGeometry
+    vtkIOImage
+    vtkIOLegacy
+    vtkIOPLY
+    vtkIOParallel
+    vtkIOXML
+    vtkImagingHybrid
+    vtkInteractionStyle
+    vtkRenderingContextOpenGL2
+    vtkRenderingCore
+    vtkRenderingFreeType
+    vtkRenderingGL2PSOpenGL2
+    vtkRenderingOpenGL2
+    )
+  find_package(VTK COMPONENTS
+    vtkCommonColor
+    vtkCommonCore
+    vtkCommonDataModel
+    vtkFiltersCore
+    vtkFiltersGeometry
+    vtkFiltersModeling
+    vtkFiltersSources
+    vtkFiltersTexture
+    vtkIOGeometry
+    vtkIOImage
+    vtkIOLegacy
+    vtkIOPLY
+    vtkIOParallel
+    vtkIOXML
+    vtkImagingHybrid
+    vtkInteractionStyle
+    vtkRenderingContextOpenGL2
+    vtkRenderingCore
+    vtkRenderingFreeType
+    vtkRenderingGL2PSOpenGL2
+    vtkRenderingOpenGL2
+    OPTIONAL_COMPONENTS
+    vtkTestingRendering
+    )
+  if (VTK_VERSION VERSION_LESS "8.90.0")
+    include(${VTK_USE_FILE})
+  endif()
 endif()
 
 set(KIT_LIBS ${VTK_LIBRARIES})
@@ -11,55 +61,59 @@ set(KIT_LIBS ${VTK_LIBRARIES})
 # Build all .cxx files in the directory
 file(GLOB ALL_FILES *.cxx)
 
-include(${WikiExamples_SOURCE_DIR}/CMake/RequiresGitLfs.cmake)
-
 foreach(SOURCE_FILE ${ALL_FILES})
   string(REPLACE ".cxx" "" TMP ${SOURCE_FILE})
   string(REPLACE ${CMAKE_CURRENT_SOURCE_DIR}/ "" EXAMPLE ${TMP})
   add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
   target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
+  if (VTK_VERSION VERSION_GREATER "8.8")
+    vtk_module_autoinit(
+      TARGETS ${WIKI}${EXAMPLE}
+      MODULES ${VTK_LIBRARIES}
+      )
+  endif()
 endforeach()
 
 if (BUILD_TESTING)
-# Testing
-set(KIT Texture)
-set(NEEDS_ARGS
-  AnimateVectors
-  ProjectedTexture
-  TextureCutSphere
-  TexturePlane
-  TexturedSphere
-  TextureThreshold
-)
+  # Testing
+  set(KIT Texture)
+  set(NEEDS_ARGS
+    AnimateVectors
+    ProjectedTexture
+    TextureCutSphere
+    TexturePlane
+    TexturedSphere
+    TextureThreshold
+    )
 
-set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
-set(TEMP ${WikiExamples_BINARY_DIR}/Testing/Temporary)
+  set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
+  set(TEMP ${WikiExamples_BINARY_DIR}/Testing/Temporary)
 
-add_test(${KIT}-AnimateVectors ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestAnimateVectors ${DATA}/carotid.vtk
-  ${DATA}/VectorAnimation/vecAnim1.vtk
-  ${DATA}/VectorAnimation/vecAnim2.vtk
-  ${DATA}/VectorAnimation/vecAnim3.vtk
-  ${DATA}/VectorAnimation/vecAnim4.vtk
-  ${DATA}/VectorAnimation/vecAnim5.vtk
-  ${DATA}/VectorAnimation/vecAnim6.vtk
-  ${DATA}/VectorAnimation/vecAnim7.vtk
-  ${DATA}/VectorAnimation/vecAnim8.vtk)
+  add_test(${KIT}-AnimateVectors ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestAnimateVectors ${DATA}/carotid.vtk
+    ${DATA}/VectorAnimation/vecAnim1.vtk
+    ${DATA}/VectorAnimation/vecAnim2.vtk
+    ${DATA}/VectorAnimation/vecAnim3.vtk
+    ${DATA}/VectorAnimation/vecAnim4.vtk
+    ${DATA}/VectorAnimation/vecAnim5.vtk
+    ${DATA}/VectorAnimation/vecAnim6.vtk
+    ${DATA}/VectorAnimation/vecAnim7.vtk
+    ${DATA}/VectorAnimation/vecAnim8.vtk)
 
-add_test(${KIT}-ProjectedTexture ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestProjectedTexture ${DATA}/fran_cut.vtk ${DATA}/fran_cut.png)
+  add_test(${KIT}-ProjectedTexture ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestProjectedTexture ${DATA}/fran_cut.vtk ${DATA}/fran_cut.png)
 
-add_test(${KIT}-TextureCutSphere ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestTextureCutSphere ${DATA}/texThres.vtk)
+  add_test(${KIT}-TextureCutSphere ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestTextureCutSphere ${DATA}/texThres.vtk)
 
-add_test(${KIT}-TexturePlane ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestTexturePlane ${DATA}/masonry.bmp)
+  add_test(${KIT}-TexturePlane ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestTexturePlane ${DATA}/masonry.bmp)
 
-add_test(${KIT}-TexturedSphere ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestTexturedSphere ${DATA}/earth.ppm)
+  add_test(${KIT}-TexturedSphere ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestTexturedSphere ${DATA}/earth.ppm)
 
-add_test(${KIT}-TextureThreshold ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestTextureThreshold ${DATA}/bluntfinxyz.bin ${DATA}/bluntfinq.bin ${DATA}/texThres2.vtk)
+  add_test(${KIT}-TextureThreshold ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestTextureThreshold ${DATA}/bluntfinxyz.bin ${DATA}/bluntfinq.bin ${DATA}/texThres2.vtk)
 
-include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
+  include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
 endif()

--- a/src/Cxx/UnstructuredGrid/CMakeLists.txt
+++ b/src/Cxx/UnstructuredGrid/CMakeLists.txt
@@ -1,18 +1,25 @@
 project (${WIKI}UnstructuredGrid)
 
-if(NOT WikiExamples_BINARY_DIR)
-find_package(VTK REQUIRED)
-if(NOT VTK_USE_RENDERING)
-  message(FATAL_ERROR "Example ${PROJECT_NAME} requires VTK_USE_RENDERING.")
-endif()
-include(${VTK_USE_FILE})
+if(NOT VTK_BINARY_DIR)
+  set(VTK_LIBRARIES "")
+  find_package(VTK COMPONENTS
+    vtkCommonColor
+    vtkCommonCore
+    vtkCommonDataModel
+    vtkInteractionStyle
+    vtkRenderingCore
+    vtkRenderingFreeType
+    vtkRenderingOpenGL2
+    OPTIONAL_COMPONENTS
+    vtkTestingRendering
+    )
+  if (VTK_VERSION VERSION_LESS "8.90.0")
+    include(${VTK_USE_FILE})
+  endif()
 endif()
 
-if("${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}" LESS 5.8)
-  set(KIT_LIBS vtkHybrid)
-else()
-  set(KIT_LIBS ${VTK_LIBRARIES})
-endif()
+set(KIT_LIBS ${VTK_LIBRARIES})
+
 #
 # Build all .cxx files in the directory
 file(GLOB ALL_FILES *.cxx)
@@ -21,10 +28,16 @@ foreach(SOURCE_FILE ${ALL_FILES})
   string(REPLACE ${CMAKE_CURRENT_SOURCE_DIR}/ "" EXAMPLE ${TMP})
   add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
   target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
+  if (NOT VTK_VERSION VERSION_LESS "8.90.0")
+    vtk_module_autoinit(
+      TARGETS ${WIKI}${EXAMPLE}
+      MODULES ${VTK_LIBRARIES}
+      )
+  endif()
 endforeach()
 
 if (BUILD_TESTING)
-# Testing
-set(KIT UnstructuredGrid)
-include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
+  # Testing
+  set(KIT UnstructuredGrid)
+  include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
 endif()

--- a/src/Cxx/Utilities/CMakeLists.txt
+++ b/src/Cxx/Utilities/CMakeLists.txt
@@ -1,26 +1,49 @@
 project (${WIKI}Utilities)
 
-if(NOT WikiExamples_BINARY_DIR)
-find_package(VTK REQUIRED)
-if(NOT VTK_USE_RENDERING)
-  message(FATAL_ERROR "Example ${PROJECT_NAME} requires VTK_USE_RENDERING.")
-endif()
-include(${VTK_USE_FILE})
+if(NOT VTK_BINARY_DIR)
+  set(VTK_LIBRARIES "")
+  find_package(VTK COMPONENTS
+    vtkCommonColor
+    vtkCommonComputationalGeometry
+    vtkCommonCore
+    vtkCommonDataModel
+    vtkCommonMisc
+    vtkCommonSystem
+    vtkCommonTransforms
+    vtkFiltersCore
+    vtkFiltersGeneral
+    vtkFiltersModeling
+    vtkFiltersProgrammable
+    vtkFiltersSources
+    vtkFiltersStatistics
+    vtkIOCore
+    vtkIOGeometry
+    vtkIOImage
+    vtkIOLegacy
+    vtkIOPLY
+    vtkIOXML
+    vtkImagingCore
+    vtkImagingHybrid
+    vtkInteractionStyle
+    vtkRenderingAnnotation
+    vtkRenderingCore
+    vtkRenderingFreeType
+    vtkRenderingOpenGL2
+    OPTIONAL_COMPONENTS
+    vtkTestingRendering
+    )
+  if (VTK_VERSION VERSION_LESS "8.90.0")
+    include(${VTK_USE_FILE})
+  endif()
 endif()
 
-if("${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}" LESS 5.8)
-  set(KIT_LIBS vtkRendering vtkHybrid vtkInfovis)
-else()
-  set(KIT_LIBS ${VTK_LIBRARIES})
-endif()
+set(KIT_LIBS ${VTK_LIBRARIES})
+
 #
 # Build all .cxx files in the directory
 file(GLOB ALL_FILES *.cxx)
 
-include(${WikiExamples_SOURCE_DIR}/CMake/RequiresSettingOn.cmake)
 Requires_Setting_On (GetDataRoot BUILD_TESTING)
-
-include(${WikiExamples_SOURCE_DIR}/CMake/RequiresVersion.cmake)
 Requires_Version(LUTUtilities "6.0.0" ALL_FILES)
 
 foreach(SOURCE_FILE ${ALL_FILES})
@@ -28,36 +51,42 @@ foreach(SOURCE_FILE ${ALL_FILES})
   string(REPLACE ${CMAKE_CURRENT_SOURCE_DIR}/ "" EXAMPLE ${TMP})
   add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
   target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
+  if (NOT VTK_VERSION VERSION_LESS "8.90.0")
+    vtk_module_autoinit(
+      TARGETS ${WIKI}${EXAMPLE}
+      MODULES ${VTK_LIBRARIES}
+      )
+  endif()
 endforeach()
 
 if (BUILD_TESTING)
-# Testing
-set(KIT Utilities)
-set(NEEDS_ARGS
-  ExtractFaces
-  SaveSceneToFieldData
-  SaveSceneToFile
-  ViewportBorders
-  ZBuffer
-)
-set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
-set(TEMP ${WikiExamples_BINARY_DIR}/Testing/Temporary)
+  # Testing
+  set(KIT Utilities)
+  set(NEEDS_ARGS
+    ExtractFaces
+    SaveSceneToFieldData
+    SaveSceneToFile
+    ViewportBorders
+    ZBuffer
+    )
+  set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
+  set(TEMP ${WikiExamples_BINARY_DIR}/Testing/Temporary)
 
-add_test(${KIT}-ExtractFaces ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestExtractFaces ${DATA}/Hexahedron.vtu ${DATA}/QuadraticPyramid.vtu ${DATA}/QuadraticTetra.vtu ${DATA}/QuadraticWedge.vtu ${DATA}/Tetrahedron.vtu ${DATA}/TriQuadraticHexahedron.vtu ${DATA}/Triangle.vtu ${DATA}/Wedge.vtu)
+  add_test(${KIT}-ExtractFaces ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestExtractFaces ${DATA}/Hexahedron.vtu ${DATA}/QuadraticPyramid.vtu ${DATA}/QuadraticTetra.vtu ${DATA}/QuadraticWedge.vtu ${DATA}/Tetrahedron.vtu ${DATA}/TriQuadraticHexahedron.vtu ${DATA}/Triangle.vtu ${DATA}/Wedge.vtu)
 
-add_test(${KIT}-SaveSceneToFile ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestSaveSceneToFile ${DATA}/Armadillo.ply ${TEMP}/Armadillo.txt)
+  add_test(${KIT}-SaveSceneToFile ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestSaveSceneToFile ${DATA}/Armadillo.ply ${TEMP}/Armadillo.txt)
 
-add_test(${KIT}-SaveSceneToFieldData ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestSaveSceneToFieldData ${DATA}/Armadillo.ply)
+  add_test(${KIT}-SaveSceneToFieldData ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestSaveSceneToFieldData ${DATA}/Armadillo.ply)
 
-add_test(${KIT}-ViewportBorders ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestViewportBorders ${DATA}/v.vtk ${DATA}/t.vtk ${DATA}/k.vtk)
+  add_test(${KIT}-ViewportBorders ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestViewportBorders ${DATA}/v.vtk ${DATA}/t.vtk ${DATA}/k.vtk)
 
-add_test(${KIT}-ZBuffer ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestZBuffer ${DATA}/Bunny.vtp ${TEMP}/ZBuffer.bmp)
+  add_test(${KIT}-ZBuffer ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestZBuffer ${DATA}/Bunny.vtp ${TEMP}/ZBuffer.bmp)
 
-include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
+  include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
 
 endif()

--- a/src/Cxx/Video/CMakeLists.txt
+++ b/src/Cxx/Video/CMakeLists.txt
@@ -1,16 +1,21 @@
 project (${WIKI}Video)
 
-if(NOT WikiExamples_BINARY_DIR)
-find_package(VTK REQUIRED)
-if(NOT VTK_USE_RENDERING)
-  message(FATAL_ERROR "Example ${PROJECT_NAME} requires VTK_USE_RENDERING.")
-endif()
-include(${VTK_USE_FILE})
+include(${WikiExamples_SOURCE_DIR}/CMake/AddOptionalIfInLibrary.cmake)
+if(NOT VTK_BINARY_DIR)
+  set(optional "")
+  Add_Optional_If_In_Library(vtkIOFFMPEG VTK_LIBRARIES optional)
+  Add_Optional_If_In_Library(vtkIOOggTheora VTK_LIBRARIES optional)
+  set(VTK_LIBRARIES "")
+  find_package(VTK COMPONENTS
+    vtkCommonCore
+    vtkImagingSources
+    ${optional}
+    )
+  if (VTK_VERSION VERSION_LESS "8.90.0")
+    include(${VTK_USE_FILE})
+  endif()
 endif()
 
-include(${WikiExamples_SOURCE_DIR}/CMake/RequiresSettingOn.cmake)
-
-Requires_Setting_On(vtkAVIWriter VTK_USE_VIDEO_FOR_WINDOWS)
 if(WIN32)
   if(VTK_USE_VIDEO_FOR_WINDOWS)
     set(KIT_LIBS ${KIT_LIBS} vfw32)

--- a/src/Cxx/Views/CMakeLists.txt
+++ b/src/Cxx/Views/CMakeLists.txt
@@ -1,18 +1,27 @@
 project (${WIKI}Views)
 
-if(NOT WikiExamples_BINARY_DIR)
-find_package(VTK REQUIRED)
-if(NOT VTK_USE_VIEWS)
-  message(FATAL_ERROR "Example ${PROJECT_NAME} requires VTK_USE_VIEWS.")
-endif()
-include(${VTK_USE_FILE})
+if(NOT VTK__BINARY_DIR)
+  set(VTK_LIBRARIES "")
+  find_package(VTK COMPONENTS
+    vtkCommonCore
+    vtkFiltersSources
+    vtkInteractionStyle
+    vtkRenderingContextOpenGL2
+    vtkRenderingCore
+    vtkRenderingFreeType
+    vtkRenderingGL2PSOpenGL2
+    vtkRenderingOpenGL2
+    vtkViewsInfovis
+    OPTIONAL_COMPONENTS
+    vtkTestingRendering
+    )
+  if (VTK_VERSION VERSION_LESS "8.90.0")
+    include(${VTK_USE_FILE})
+  endif()
 endif()
 
-if("${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}" LESS 5.8)
-  set(KIT_LIBS vtkWidgets vtkRendering vtkHybrid vtkViews)
-else()
-  set(KIT_LIBS ${VTK_LIBRARIES})
-endif()
+set(KIT_LIBS ${VTK_LIBRARIES})
+
 #
 # Build all .cxx files in the directory
 file(GLOB ALL_FILES *.cxx)
@@ -21,4 +30,10 @@ foreach(SOURCE_FILE ${ALL_FILES})
   string(REPLACE ${CMAKE_CURRENT_SOURCE_DIR}/ "" EXAMPLE ${TMP})
   add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
   target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
+  if (VTK_VERSION VERSION_GREATER "8.8")
+    vtk_module_autoinit(
+      TARGETS ${WIKI}${EXAMPLE}
+      MODULES ${VTK_LIBRARIES}
+      )
+  endif()
 endforeach()

--- a/src/Cxx/Visualization/CMakeLists.txt
+++ b/src/Cxx/Visualization/CMakeLists.txt
@@ -1,8 +1,55 @@
 project (${WIKI}Visualization)
 
-if(NOT WikiExamples_BINARY_DIR)
-find_package(VTK REQUIRED)
-  include(${VTK_USE_FILE})
+if(NOT VTK_BINARY_DIR)
+  set(optional "")
+  Add_Optional_If_In_Library(SplineDrivenImageSlicer VTK_LIBRARIES optional)
+  set(VTK_LIBRARIES "")
+  find_package(VTK COMPONENTS
+    vtkCommonColor
+    vtkCommonComputationalGeometry
+    vtkCommonCore
+    vtkCommonDataModel
+    vtkCommonExecutionModel
+    vtkCommonMath
+    vtkCommonSystem
+    vtkCommonTransforms
+    vtkFiltersCore
+    vtkFiltersFlowPaths
+    vtkFiltersGeneral
+    vtkFiltersGeometry
+    vtkFiltersHybrid
+    vtkFiltersModeling
+    vtkFiltersProgrammable
+    vtkFiltersSources
+    vtkFiltersTexture
+    vtkIOGeometry
+    vtkIOImage
+    vtkIOLegacy
+    vtkIOPLY
+    vtkIOParallel
+    vtkIOXML
+    vtkImagingColor
+    vtkImagingCore
+    vtkImagingGeneral
+    vtkImagingHybrid
+    vtkImagingMorphological
+    vtkImagingSources
+    vtkInteractionImage
+    vtkInteractionStyle
+    vtkInteractionWidgets
+    vtkRenderingAnnotation
+    vtkRenderingCore
+    vtkRenderingFreeType
+    vtkRenderingLOD
+    vtkRenderingLabel
+    vtkRenderingOpenGL2
+    ${optional}
+    OPTIONAL_COMPONENTS
+    vtkTestingRendering
+    )
+  if (VTK_VERSION VERSION_LESS "8.90.0")
+    include(${VTK_USE_FILE})
+  endif()
 endif()
 
 set(KIT_LIBS ${VTK_LIBRARIES})
@@ -11,11 +58,6 @@ set(KIT_LIBS ${VTK_LIBRARIES})
 # Build all .cxx files in the directory
 
 file(GLOB ALL_FILES *.cxx)
-
-include(${WikiExamples_SOURCE_DIR}/CMake/RequiresVersion.cmake)
-include(${WikiExamples_SOURCE_DIR}/CMake/RequiresModule.cmake)
-include(${WikiExamples_SOURCE_DIR}/CMake/RequiresSettingOff.cmake)
-include(${WikiExamples_SOURCE_DIR}/CMake/RequiresGitLfs.cmake)
 
 set(VERSION_MIN "6.0.0")
 Requires_Version(AssignCellColorsFromLUT ${VERSION_MIN} ALL_FILES)
@@ -45,180 +87,186 @@ foreach(SOURCE_FILE ${ALL_FILES})
   string(REPLACE ${CMAKE_CURRENT_SOURCE_DIR}/ "" EXAMPLE ${TMP})
   add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
   target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
+  if (NOT VTK_VERSION VERSION_LESS "8.90.0")
+    vtk_module_autoinit(
+      TARGETS ${WIKI}${EXAMPLE}
+      MODULES ${VTK_LIBRARIES}
+      )
+  endif()
 endforeach()
 
 if (BUILD_TESTING)
-# Testing
-set(KIT Visualization)
-set(NEEDS_ARGS
-  AlphaFrequency
-  Arbitrary3DCursor
-  BackgroundTexture
-  Blow
-  BlobbyLogo
-  BoxClipStructuredPoints
-  BoxClipUnstructuredGrid
-  ChooseTextColor
-  ChooseTextColorDemo
-  ClipArt
-  ComplexV
-  CorrectlyRenderTranslucentGeometry
-  CreateColorSeriesDemo
-  CurvedReformation
-  DepthSortPolyData
-  ExtrudePolyDataAlongLine
-  FlyingFrogSkinAndTissue
-  FlyingFrogSkinAndTissueB
-  FlyingFrogSkinAndTissueC
-  FontFile
-  FrogSlice
-  Glyph3DImage
-  Glyph3DMapper
-  HanoiInitial
-  HanoiIntermediate
-  Hawaii
-  HedgeHog
-  Kitchen
-  NormalsDemo
-  PointDataSubdivision
-  RenderLargeImage
-  SelectWindowRegion
-  ShepardInterpolation
-  StreamLines
-  TextureMapPlane
-  TextureMapQuad
-  ViewFrog
-  ViewFrogA
-  ViewFrogBoth
-  ViewFrogSkinAndTissue
-  VisualizeVTP
-  Visualize2DPoints
-)
+  # Testing
+  set(KIT Visualization)
+  set(NEEDS_ARGS
+    AlphaFrequency
+    Arbitrary3DCursor
+    BackgroundTexture
+    Blow
+    BlobbyLogo
+    BoxClipStructuredPoints
+    BoxClipUnstructuredGrid
+    ChooseTextColor
+    ChooseTextColorDemo
+    ClipArt
+    ComplexV
+    CorrectlyRenderTranslucentGeometry
+    CreateColorSeriesDemo
+    CurvedReformation
+    DepthSortPolyData
+    ExtrudePolyDataAlongLine
+    FlyingFrogSkinAndTissue
+    FlyingFrogSkinAndTissueB
+    FlyingFrogSkinAndTissueC
+    FontFile
+    FrogSlice
+    Glyph3DImage
+    Glyph3DMapper
+    HanoiInitial
+    HanoiIntermediate
+    Hawaii
+    HedgeHog
+    Kitchen
+    NormalsDemo
+    PointDataSubdivision
+    RenderLargeImage
+    SelectWindowRegion
+    ShepardInterpolation
+    StreamLines
+    TextureMapPlane
+    TextureMapQuad
+    ViewFrog
+    ViewFrogA
+    ViewFrogBoth
+    ViewFrogSkinAndTissue
+    VisualizeVTP
+    Visualize2DPoints
+    )
 
-set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
-set(TEMP ${WikiExamples_BINARY_DIR}/Testmake rebuing/Temporary)
+  set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
+  set(TEMP ${WikiExamples_BINARY_DIR}/Testmake rebuing/Temporary)
 
-add_test(${KIT}-AlphaFrequency ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestAlphaFrequency ${DATA}/Gettysburg.txt)
+  add_test(${KIT}-AlphaFrequency ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestAlphaFrequency ${DATA}/Gettysburg.txt)
 
-add_test(${KIT}-Arbitrary3DCursor ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestArbitrary3DCursor ${DATA}/Bunny.vtp)
+  add_test(${KIT}-Arbitrary3DCursor ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestArbitrary3DCursor ${DATA}/Bunny.vtp)
 
-add_test(${KIT}-BackgroundTexture ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestBackgroundTexture -E 30)
+  add_test(${KIT}-BackgroundTexture ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestBackgroundTexture -E 30)
 
-add_test(${KIT}-Blow ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestBlow ${DATA}/blow.vtk)
+  add_test(${KIT}-Blow ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestBlow ${DATA}/blow.vtk)
 
-add_test(${KIT}-BlobbyLogo ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestBlobbyLogo ${DATA}/v.vtk ${DATA}/t.vtk ${DATA}/k.vtk)
+  add_test(${KIT}-BlobbyLogo ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestBlobbyLogo ${DATA}/v.vtk ${DATA}/t.vtk ${DATA}/k.vtk)
 
-add_test(${KIT}-BoxClipStructuredPoints ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestBoxClipStructuredPoints ${DATA}/HeadMRVolume.mhd)
+  add_test(${KIT}-BoxClipStructuredPoints ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestBoxClipStructuredPoints ${DATA}/HeadMRVolume.mhd)
 
-add_test(${KIT}-BoxClipUnstructuredGrid ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestBoxClipUnstructuredGrid ${DATA}/hexa.vtk)
+  add_test(${KIT}-BoxClipUnstructuredGrid ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestBoxClipUnstructuredGrid ${DATA}/hexa.vtk)
 
-add_test(${KIT}-ComplexV ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestComplexV ${DATA}/carotid.vtk)
+  add_test(${KIT}-ComplexV ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestComplexV ${DATA}/carotid.vtk)
 
-add_test(${KIT}-ClipArt ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestClipArt ${DATA}/stormy.jpg)
+  add_test(${KIT}-ClipArt ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestClipArt ${DATA}/stormy.jpg)
 
-add_test(${KIT}-ChooseTextColor ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestChooseTextColor ${DATA}/Canterbury.ttf Pink  MintCream SaddleBrown)
+  add_test(${KIT}-ChooseTextColor ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestChooseTextColor ${DATA}/Canterbury.ttf Pink  MintCream SaddleBrown)
 
-add_test(${KIT}-ChooseTextColorDemo ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestChooseTextColorDemo .8 mintcream ivoryblack)
+  add_test(${KIT}-ChooseTextColorDemo ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestChooseTextColorDemo .8 mintcream ivoryblack)
 
-add_test(${KIT}-CorrectlyRenderTranslucentGeometry ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestCorrectlyRenderTranslucentGeometry 100 100 50 0.1 0 0)
+  add_test(${KIT}-CorrectlyRenderTranslucentGeometry ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestCorrectlyRenderTranslucentGeometry 100 100 50 0.1 0 0)
 
-add_test(${KIT}-CreateColorSeriesDemo ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestCreateColorSeriesDemo Yellow)
+  add_test(${KIT}-CreateColorSeriesDemo ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestCreateColorSeriesDemo Yellow)
 
-add_test(${KIT}-CurvedReformation ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestCurvedReformation ${DATA}/HeadMRVolume.mhd ${DATA}/polyline.vtk 200)
+  add_test(${KIT}-CurvedReformation ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestCurvedReformation ${DATA}/HeadMRVolume.mhd ${DATA}/polyline.vtk 200)
 
-add_test(${KIT}-DepthSortPolyData ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestDepthSortPolyData 1 100 100 0)
+  add_test(${KIT}-DepthSortPolyData ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestDepthSortPolyData 1 100 100 0)
 
-if (SplineDrivenImageSlicer_LOADED)
-  add_test(${KIT}-ExtrudePolyDataAlongLine ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-    TestExtrudePolyDataAlongLine ${DATA}/a.vtp)
-endif()
+  if (SplineDrivenImageSlicer_LOADED)
+    add_test(${KIT}-ExtrudePolyDataAlongLine ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+      TestExtrudePolyDataAlongLine ${DATA}/a.vtp)
+  endif()
 
-add_test(${KIT}-FontFile ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestFontFile ${DATA}/CopyPaste.ttf)
+  add_test(${KIT}-FontFile ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestFontFile ${DATA}/CopyPaste.ttf)
 
-add_test(${KIT}-Glyph3DImage ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestGlyph3DImage ${DATA}/emote.jpg)
+  add_test(${KIT}-Glyph3DImage ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestGlyph3DImage ${DATA}/emote.jpg)
 
-add_test(${KIT}-Glyph3DMapper ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestGlyph3DMapper -E 40)
+  add_test(${KIT}-Glyph3DMapper ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestGlyph3DMapper -E 40)
 
-add_test(${KIT}-HanoiInitial ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestHanoiInitial -c 1)
+  add_test(${KIT}-HanoiInitial ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestHanoiInitial -c 1)
 
-add_test(${KIT}-HanoiIntermediate ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestHanoiIntermediate -c 2)
+  add_test(${KIT}-HanoiIntermediate ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestHanoiIntermediate -c 2)
 
-if(GIT_LFS)
-  add_test(${KIT}-FlyingFrogSkinAndTissue ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-    TestFlyingFrogSkinAndTissue ${DATA}/Frog/frog.mhd ${DATA}/Frog/frogtissue.mhd)
-  add_test(${KIT}-FlyingFrogSkinAndTissueB ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-    TestFlyingFrogSkinAndTissueB ${DATA}/Frog/frog.mhd ${DATA}/Frog/frogtissue.mhd 1)
-  add_test(${KIT}-FlyingFrogSkinAndTissueC ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-    TestFlyingFrogSkinAndTissueC ${DATA}/Frog/frog.mhd ${DATA}/Frog/frogtissue.mhd 1 1)
-  add_test(${KIT}-FrogSlice ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-    TestFrogSlice ${DATA}/Frog/frog.mhd ${DATA}/Frog/frogtissue.mhd)
-  add_test(${KIT}-Hawaii ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-    TestHawaii ${DATA}/honolulu.vtk)
-  add_test(${KIT}-ViewFrog ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-    TestViewFrog ${DATA}/Frog/frogtissue.mhd blood brain duodenum eyeRetina eyeWhite heart ileum kidney intestine liver lung nerve skeleton spleen stomach)
-  add_test(${KIT}-ViewFrogA ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-    TestViewFrogA ${DATA}/Frog/frogtissue.mhd blood brain duodenum eyeRetina eyeWhite heart ileum kidney intestine liver lung nerve spleen stomach)
-  add_test(${KIT}-ViewFrogBoth ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-    TestViewFrogBoth ${DATA}/Frog/frogtissue.mhd brain)
-  add_test(${KIT}-ViewFrogSkinAndTissue ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-    TestViewFrogSkinAndTissue ${DATA}/Frog/frog.mhd ${DATA}/Frog/frogtissue.mhd)
-endif()
+  if(GIT_LFS)
+    add_test(${KIT}-FlyingFrogSkinAndTissue ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+      TestFlyingFrogSkinAndTissue ${DATA}/Frog/frog.mhd ${DATA}/Frog/frogtissue.mhd)
+    add_test(${KIT}-FlyingFrogSkinAndTissueB ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+      TestFlyingFrogSkinAndTissueB ${DATA}/Frog/frog.mhd ${DATA}/Frog/frogtissue.mhd 1)
+    add_test(${KIT}-FlyingFrogSkinAndTissueC ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+      TestFlyingFrogSkinAndTissueC ${DATA}/Frog/frog.mhd ${DATA}/Frog/frogtissue.mhd 1 1)
+    add_test(${KIT}-FrogSlice ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+      TestFrogSlice ${DATA}/Frog/frog.mhd ${DATA}/Frog/frogtissue.mhd)
+    add_test(${KIT}-Hawaii ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+      TestHawaii ${DATA}/honolulu.vtk)
+    add_test(${KIT}-ViewFrog ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+      TestViewFrog ${DATA}/Frog/frogtissue.mhd blood brain duodenum eyeRetina eyeWhite heart ileum kidney intestine liver lung nerve skeleton spleen stomach)
+    add_test(${KIT}-ViewFrogA ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+      TestViewFrogA ${DATA}/Frog/frogtissue.mhd blood brain duodenum eyeRetina eyeWhite heart ileum kidney intestine liver lung nerve spleen stomach)
+    add_test(${KIT}-ViewFrogBoth ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+      TestViewFrogBoth ${DATA}/Frog/frogtissue.mhd brain)
+    add_test(${KIT}-ViewFrogSkinAndTissue ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+      TestViewFrogSkinAndTissue ${DATA}/Frog/frog.mhd ${DATA}/Frog/frogtissue.mhd)
+  endif()
 
-add_test(${KIT}-HedgeHog ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestHedgeHog -E 50)
+  add_test(${KIT}-HedgeHog ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestHedgeHog -E 50)
 
-add_test(${KIT}-Kitchen ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestKitchen ${DATA}/kitchen.vtk)
+  add_test(${KIT}-Kitchen ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestKitchen ${DATA}/kitchen.vtk)
 
-add_test(${KIT}-NormalsDemo ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestNormalsDemo ${DATA}/42400-IDGH.stl)
+  add_test(${KIT}-NormalsDemo ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestNormalsDemo ${DATA}/42400-IDGH.stl)
 
-add_test(${KIT}-PointDataSubdivision ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestPointDataSubdivision 2)
+  add_test(${KIT}-PointDataSubdivision ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestPointDataSubdivision 2)
 
-add_test(${KIT}-RenderLargeImage ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestRenderLargeImage ${DATA}/Bunny.vtp ${TEMP}/Bunny.png 4)
+  add_test(${KIT}-RenderLargeImage ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestRenderLargeImage ${DATA}/Bunny.vtp ${TEMP}/Bunny.png 4)
 
-add_test(${KIT}-SelectWindowRegion ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestSelectWindowRegion ${DATA}/Ox.jpg)
+  add_test(${KIT}-SelectWindowRegion ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestSelectWindowRegion ${DATA}/Ox.jpg)
 
-add_test(${KIT}-ShepardInterpolation ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestShepardInterpolation ${DATA}/cowHead.vtp 100)
+  add_test(${KIT}-ShepardInterpolation ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestShepardInterpolation ${DATA}/cowHead.vtp 100)
 
-add_test(${KIT}-StreamLines ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestStreamLines ${DATA}/combxyz.bin ${DATA}/combq.bin)
+  add_test(${KIT}-StreamLines ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestStreamLines ${DATA}/combxyz.bin ${DATA}/combq.bin)
 
-add_test(${KIT}-TextureMapPlane ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestTextureMapPlane ${DATA}/Yinyang.jpg)
+  add_test(${KIT}-TextureMapPlane ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestTextureMapPlane ${DATA}/Yinyang.jpg)
 
-add_test(${KIT}-TextureMapQuad ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestTextureMapQuad ${DATA}/Yinyang.jpg)
+  add_test(${KIT}-TextureMapQuad ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestTextureMapQuad ${DATA}/Yinyang.jpg)
 
-add_test(${KIT}-VisualizeVTP ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestVisualizeVTP ${DATA}/Bunny.vtp)
+  add_test(${KIT}-VisualizeVTP ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestVisualizeVTP ${DATA}/Bunny.vtp)
 
-add_test(${KIT}-Visualize2DPoints ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestVisualize2DPoints ${DATA}/Ring.vtp)
+  add_test(${KIT}-Visualize2DPoints ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestVisualize2DPoints ${DATA}/Ring.vtp)
 
-include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
+  include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
 endif()

--- a/src/Cxx/VisualizationAlgorithms/CMakeLists.txt
+++ b/src/Cxx/VisualizationAlgorithms/CMakeLists.txt
@@ -1,8 +1,46 @@
 project (${WIKI}VisualizationAlgorithms)
 
-if(NOT WikiExamples_BINARY_DIR)
-  find_package(VTK REQUIRED)
-  include(${VTK_USE_FILE})
+if(NOT VTK_BINARY_DIR)
+  set(VTK_LIBRARIES "")
+  find_package(VTK COMPONENTS
+    vtkCommonColor
+    vtkCommonComputationalGeometry
+    vtkCommonCore
+    vtkCommonDataModel
+    vtkCommonMath
+    vtkCommonTransforms
+    vtkFiltersCore
+    vtkFiltersExtraction
+    vtkFiltersFlowPaths
+    vtkFiltersGeneral
+    vtkFiltersGeometry
+    vtkFiltersHybrid
+    vtkFiltersModeling
+    vtkFiltersSources
+    vtkFiltersTexture
+    vtkIOGeometry
+    vtkIOImage
+    vtkIOLegacy
+    vtkIOParallel
+    vtkIOXML
+    vtkImagingColor
+    vtkImagingCore
+    vtkImagingGeneral
+    vtkImagingHybrid
+    vtkInteractionImage
+    vtkInteractionStyle
+    vtkInteractionWidgets
+    vtkRenderingAnnotation
+    vtkRenderingCore
+    vtkRenderingFreeType
+    vtkRenderingLOD
+    vtkRenderingOpenGL2
+    OPTIONAL_COMPONENTS
+    vtkTestingRendering
+    )
+  if (VTK_VERSION VERSION_LESS "8.90.0")
+    include(${VTK_USE_FILE})
+  endif()
 endif()
 
 set(KIT_LIBS ${VTK_LIBRARIES})
@@ -10,8 +48,6 @@ set(KIT_LIBS ${VTK_LIBRARIES})
 #
 # Build all .cxx files in the directory
 file(GLOB ALL_FILES *.cxx)
-
-include(${WikiExamples_SOURCE_DIR}/CMake/RequiresGitLfs.cmake)
 
 Requires_GitLfs(PineRootConnectivity ALL_FILES)
 Requires_GitLfs(PineRootConnectivityA ALL_FILES)
@@ -23,192 +59,198 @@ foreach(SOURCE_FILE ${ALL_FILES})
   string(REPLACE ${CMAKE_CURRENT_SOURCE_DIR}/ "" EXAMPLE ${TMP})
   add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
   target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
+  if (NOT VTK_VERSION VERSION_LESS "8.90.0")
+    vtk_module_autoinit(
+      TARGETS ${WIKI}${EXAMPLE}
+      MODULES ${VTK_LIBRARIES}
+      )
+  endif()
 endforeach()
 
 if (BUILD_TESTING)
-# Testing
-set(KIT VisualizationAlgorithms)
-set(NEEDS_ARGS
-  AnatomicalOrientation
-  BluntStreamlines
-  CarotidFlow
-  CarotidFlowGlyphs
-  ColorIsosurface
-  CombustorIsosurface
-  CreateBFont
-  CutStructuredGrid
-  CutWithCutFunction
-  CutWithScalars
-  DecimateFran
-  DecimateHawaii
-  DisplacementPlot
-  FilledContours
-  FindCellIntersections
-  FlyingHeadSlice
-  HeadBone
-  HeadSlice
-  Hello
-  ImageGradient
-  IronIsoSurface
-  LOx
-  LOxGrid
-  LOxSeeds
-  Motor
-  MarchingCases
-  MarchingCasesA
-  MarchingCasesB
-  MarchingCasesC
-  MarchingCasesD
-  PineRootConnectivity
-  PineRootConnectivityA
-  PineRootDecimation
-  PlateVibration
-  ProbeCombustor
-  Office
-  OfficeA
-  OfficeTube
-  SpikeFran
-  SplatFace
-  Stocks
-  StreamlinesWithLineWidget
-  VelocityProfile
-  WarpCombustor
-)
-set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
+  # Testing
+  set(KIT VisualizationAlgorithms)
+  set(NEEDS_ARGS
+    AnatomicalOrientation
+    BluntStreamlines
+    CarotidFlow
+    CarotidFlowGlyphs
+    ColorIsosurface
+    CombustorIsosurface
+    CreateBFont
+    CutStructuredGrid
+    CutWithCutFunction
+    CutWithScalars
+    DecimateFran
+    DecimateHawaii
+    DisplacementPlot
+    FilledContours
+    FindCellIntersections
+    FlyingHeadSlice
+    HeadBone
+    HeadSlice
+    Hello
+    ImageGradient
+    IronIsoSurface
+    LOx
+    LOxGrid
+    LOxSeeds
+    Motor
+    MarchingCases
+    MarchingCasesA
+    MarchingCasesB
+    MarchingCasesC
+    MarchingCasesD
+    PineRootConnectivity
+    PineRootConnectivityA
+    PineRootDecimation
+    PlateVibration
+    ProbeCombustor
+    Office
+    OfficeA
+    OfficeTube
+    SpikeFran
+    SplatFace
+    Stocks
+    StreamlinesWithLineWidget
+    VelocityProfile
+    WarpCombustor
+    )
+  set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
 
-add_test(${KIT}-AnatomicalOrientation ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestAnatomicalOrientation ${DATA}/Human.vtp)
+  add_test(${KIT}-AnatomicalOrientation ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestAnatomicalOrientation ${DATA}/Human.vtp)
 
-add_test(${KIT}-BluntStreamlines ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestBluntStreamlines ${DATA}/bluntfinxyz.bin ${DATA}/bluntfinq.bin)
+  add_test(${KIT}-BluntStreamlines ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestBluntStreamlines ${DATA}/bluntfinxyz.bin ${DATA}/bluntfinq.bin)
 
-add_test(${KIT}-CarotidFlow ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestCarotidFlow ${DATA}/carotid.vtk -E 50)
+  add_test(${KIT}-CarotidFlow ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestCarotidFlow ${DATA}/carotid.vtk -E 50)
 
-add_test(${KIT}-CarotidFlowGlyphs ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestCarotidFlowGlyphs ${DATA}/carotid.vtk -E 50)
+  add_test(${KIT}-CarotidFlowGlyphs ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestCarotidFlowGlyphs ${DATA}/carotid.vtk -E 50)
 
-add_test(${KIT}-ColorIsosurface ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestColorIsosurface ${DATA}/combxyz.bin ${DATA}/combq.bin)
+  add_test(${KIT}-ColorIsosurface ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestColorIsosurface ${DATA}/combxyz.bin ${DATA}/combq.bin)
 
-add_test(${KIT}-CombustorIsosurface ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestCombustorIsosurface ${DATA}/combxyz.bin ${DATA}/combq.bin)
+  add_test(${KIT}-CombustorIsosurface ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestCombustorIsosurface ${DATA}/combxyz.bin ${DATA}/combq.bin)
 
-add_test(${KIT}-CreateBFont ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestCreateBFont ${DATA}/B.pgm)
+  add_test(${KIT}-CreateBFont ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestCreateBFont ${DATA}/B.pgm)
 
-add_test(${KIT}-CutStructuredGrid ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestCutStructuredGrid ${DATA}/combxyz.bin ${DATA}/combq.bin)
+  add_test(${KIT}-CutStructuredGrid ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestCutStructuredGrid ${DATA}/combxyz.bin ${DATA}/combq.bin)
 
-add_test(${KIT}-CutWithCutFunction ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestCutWithCutFunction ${DATA}/Torso.vtp 20)
+  add_test(${KIT}-CutWithCutFunction ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestCutWithCutFunction ${DATA}/Torso.vtp 20)
 
-add_test(${KIT}-CutWithScalars ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestCutWithScalars ${DATA}/Torso.vtp 20)
+  add_test(${KIT}-CutWithScalars ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestCutWithScalars ${DATA}/Torso.vtp 20)
 
-add_test(${KIT}-DecimateFran ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestDecimateFran ${DATA}/fran_cut.vtk ${DATA}/fran_cut.png)
+  add_test(${KIT}-DecimateFran ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestDecimateFran ${DATA}/fran_cut.vtk ${DATA}/fran_cut.png)
 
-add_test(${KIT}-DisplacementPlot ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestDisplacementPlot ${DATA}/plate.vtk)
+  add_test(${KIT}-DisplacementPlot ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestDisplacementPlot ${DATA}/plate.vtk)
 
-add_test(${KIT}-FilledContours ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestFilledContours ${DATA}/filledContours.vtp 10)
+  add_test(${KIT}-FilledContours ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestFilledContours ${DATA}/filledContours.vtp 10)
 
-add_test(${KIT}-FindCellIntersections ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestFindCellIntersections ${DATA}/Disc_BiQuadraticQuads_0_0.vtu)
+  add_test(${KIT}-FindCellIntersections ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestFindCellIntersections ${DATA}/Disc_BiQuadraticQuads_0_0.vtu)
 
-add_test(${KIT}-FlyingHeadSlice ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestFlyingHeadSlice ${DATA}/FullHead.mhd)
+  add_test(${KIT}-FlyingHeadSlice ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestFlyingHeadSlice ${DATA}/FullHead.mhd)
 
-add_test(${KIT}-HeadBone ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestHeadBone ${DATA}/FullHead.mhd)
+  add_test(${KIT}-HeadBone ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestHeadBone ${DATA}/FullHead.mhd)
 
-add_test(${KIT}-HeadSlice ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestHeadSlice ${DATA}/FullHead.mhd)
+  add_test(${KIT}-HeadSlice ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestHeadSlice ${DATA}/FullHead.mhd)
 
-add_test(${KIT}-Hello ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestHello ${DATA}/hello.vtk)
+  add_test(${KIT}-Hello ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestHello ${DATA}/hello.vtk)
 
-add_test(${KIT}-ImageGradient ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestImageGradient ${DATA}/FullHead.mhd)
+  add_test(${KIT}-ImageGradient ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestImageGradient ${DATA}/FullHead.mhd)
 
-add_test(${KIT}-IronIsoSurface ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestIronIsoSurface ${DATA}/ironProt.vtk)
+  add_test(${KIT}-IronIsoSurface ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestIronIsoSurface ${DATA}/ironProt.vtk)
 
-add_test(${KIT}-LOx ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestLOx ${DATA}/postxyz.bin ${DATA}/postq.bin)
+  add_test(${KIT}-LOx ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestLOx ${DATA}/postxyz.bin ${DATA}/postq.bin)
 
-add_test(${KIT}-LOxGrid ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestLOxGrid ${DATA}/postxyz.bin ${DATA}/postq.bin)
+  add_test(${KIT}-LOxGrid ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestLOxGrid ${DATA}/postxyz.bin ${DATA}/postq.bin)
 
-add_test(${KIT}-LOxSeeds ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestLOxSeeds ${DATA}/postxyz.bin ${DATA}/postq.bin)
+  add_test(${KIT}-LOxSeeds ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestLOxSeeds ${DATA}/postxyz.bin ${DATA}/postq.bin)
 
-add_test(${KIT}-MarchingCases ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestMarchingCases 1 7)
+  add_test(${KIT}-MarchingCases ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestMarchingCases 1 7)
 
-add_test(${KIT}-MarchingCasesA ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestMarchingCasesA 15 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14)
+  add_test(${KIT}-MarchingCasesA ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestMarchingCasesA 15 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14)
 
-add_test(${KIT}-MarchingCasesB ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestMarchingCasesB 6 -3 -6 -7 -10 -12 -13)
+  add_test(${KIT}-MarchingCasesB ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestMarchingCasesB 6 -3 -6 -7 -10 -12 -13)
 
-add_test(${KIT}-MarchingCasesC ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestMarchingCasesC 1 3 1 0)
+  add_test(${KIT}-MarchingCasesC ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestMarchingCasesC 1 3 1 0)
 
-add_test(${KIT}-MarchingCasesD ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestMarchingCasesD 1 7 2 0)
+  add_test(${KIT}-MarchingCasesD ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestMarchingCasesD 1 7 2 0)
 
-add_test(${KIT}-Motor ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestMotor ${DATA}/texThres2.vtk ${DATA}/motor.g)
+  add_test(${KIT}-Motor ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestMotor ${DATA}/texThres2.vtk ${DATA}/motor.g)
 
-add_test(${KIT}-PlateVibration ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestPlateVibration ${DATA}/plate.vtk -E 30)
+  add_test(${KIT}-PlateVibration ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestPlateVibration ${DATA}/plate.vtk -E 30)
 
-add_test(${KIT}-ProbeCombustor ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestProbeCombustor ${DATA}/combxyz.bin ${DATA}/combq.bin -E 50)
+  add_test(${KIT}-ProbeCombustor ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestProbeCombustor ${DATA}/combxyz.bin ${DATA}/combq.bin -E 50)
 
-add_test(${KIT}-Office ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestOffice ${DATA}/office.binary.vtk 3 -E 80)
+  add_test(${KIT}-Office ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestOffice ${DATA}/office.binary.vtk 3 -E 80)
 
-add_test(${KIT}-OfficeA ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestOfficeA ${DATA}/office.binary.vtk 0 -E 50)
+  add_test(${KIT}-OfficeA ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestOfficeA ${DATA}/office.binary.vtk 0 -E 50)
 
-add_test(${KIT}-OfficeTube ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestOfficeTube ${DATA}/office.binary.vtk)
+  add_test(${KIT}-OfficeTube ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestOfficeTube ${DATA}/office.binary.vtk)
 
-add_test(${KIT}-SpikeFran ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestSpikeFran ${DATA}/fran_cut.vtk)
+  add_test(${KIT}-SpikeFran ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestSpikeFran ${DATA}/fran_cut.vtk)
 
-add_test(${KIT}-SplatFace ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestSplatFace ${DATA}/fran_cut.vtk -E 50)
+  add_test(${KIT}-SplatFace ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestSplatFace ${DATA}/fran_cut.vtk -E 50)
 
-add_test(${KIT}-Stocks ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestStocks ${DATA}/GE.vtk ${DATA}/GM.vtk ${DATA}/IBM.vtk ${DATA}/DEC.vtk 0)
+  add_test(${KIT}-Stocks ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestStocks ${DATA}/GE.vtk ${DATA}/GM.vtk ${DATA}/IBM.vtk ${DATA}/DEC.vtk 0)
 
-add_test(${KIT}-StreamlinesWithLineWidget ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestStreamlinesWithLineWidget ${DATA}/combxyz.bin ${DATA}/combq.bin 10 1 -E 20)
+  add_test(${KIT}-StreamlinesWithLineWidget ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestStreamlinesWithLineWidget ${DATA}/combxyz.bin ${DATA}/combq.bin 10 1 -E 20)
 
-add_test(${KIT}-VelocityProfile ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestVelocityProfile ${DATA}/combxyz.bin ${DATA}/combq.bin)
+  add_test(${KIT}-VelocityProfile ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestVelocityProfile ${DATA}/combxyz.bin ${DATA}/combq.bin)
 
-add_test(${KIT}-WarpCombustor ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestWarpCombustor ${DATA}/combxyz.bin ${DATA}/combq.bin)
+  add_test(${KIT}-WarpCombustor ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestWarpCombustor ${DATA}/combxyz.bin ${DATA}/combq.bin)
 
-if(GIT_LFS)
-  add_test(${KIT}-DecimateHawaii ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-    TestDecimateHawaii ${DATA}/honolulu.vtk -E 50)
+  if(GIT_LFS)
+    add_test(${KIT}-DecimateHawaii ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+      TestDecimateHawaii ${DATA}/honolulu.vtk -E 50)
 
-  add_test(${KIT}-PineRootConnectivity ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-    TestPineRootConnectivity ${DATA}/pine_root.tri -E 20)
+    add_test(${KIT}-PineRootConnectivity ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+      TestPineRootConnectivity ${DATA}/pine_root.tri -E 20)
 
-  add_test(${KIT}-PineRootConnectivityA ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-    TestPineRootConnectivityA ${DATA}/pine_root.tri 1 -E 20)
+    add_test(${KIT}-PineRootConnectivityA ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+      TestPineRootConnectivityA ${DATA}/pine_root.tri 1 -E 20)
 
-  add_test(${KIT}-PineRootDecimation ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-    TestPineRootDecimation ${DATA}/pine_root.tri -E 20)
-endif()
+    add_test(${KIT}-PineRootDecimation ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+      TestPineRootDecimation ${DATA}/pine_root.tri -E 20)
+  endif()
 
-include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
+  include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
 endif()

--- a/src/Cxx/VolumeRendering/CMakeLists.txt
+++ b/src/Cxx/VolumeRendering/CMakeLists.txt
@@ -1,8 +1,33 @@
 project (${WIKI}VolumeRendering)
 
 if(NOT WikiExamples_BINARY_DIR)
-  find_package(VTK REQUIRED)
-  include(${VTK_USE_FILE})
+  set(VTK_LIBRARIES "")
+  find_package(VTK COMPONENTS
+    vtkCommonColor
+    vtkCommonCore
+    vtkCommonDataModel
+    vtkFiltersCore
+    vtkFiltersExtraction
+    vtkFiltersGeneral
+    vtkIOImage
+    vtkIOLegacy
+    vtkIOParallel
+    vtkIOXML
+    vtkImagingCore
+    vtkImagingHybrid
+    vtkInteractionStyle
+    vtkInteractionWidgets
+    vtkRenderingContextOpenGL2
+    vtkRenderingCore
+    vtkRenderingFreeType
+    vtkRenderingGL2PSOpenGL2
+    vtkRenderingOpenGL2
+    vtkRenderingVolume
+    vtkRenderingVolumeOpenGL2
+    )
+  if (VTK_VERSION VERSION_LESS "8.90.0")
+    include(${VTK_USE_FILE})
+  endif()
 endif()
 
 set(KIT_LIBS ${VTK_LIBRARIES})
@@ -23,52 +48,58 @@ foreach(SOURCE_FILE ${ALL_FILES})
   string(REPLACE ${CMAKE_CURRENT_SOURCE_DIR}/ "" EXAMPLE ${TMP})
   add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
   target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
+  if (NOT VTK_VERSION VERSION_LESS "8.90.0")
+    vtk_module_autoinit(
+      TARGETS ${WIKI}${EXAMPLE}
+      MODULES ${VTK_LIBRARIES}
+      )
+  endif()
 endforeach()
 
 if (BUILD_TESTING)
-# Testing
-set(KIT VolumeRendering)
-if (VTK_RENDERING_BACKEND STREQUAL "OpenGL2")
-  set(NEEDS_ARGS
-    PseudoVolumeRendering
-    MinIntensityRendering
-    IntermixedUnstructuredGrid
-    FixedPointVolumeRayCastMapperCT
-    SimpleRayCast
-  )
-else()
-  set(NEEDS_ARGS
-    HAVSVolumeMapper
-    MinIntensityRendering
-    IntermixedUnstructuredGrid
-  )
-endif()
+  # Testing
+  set(KIT VolumeRendering)
+  if (VTK_RENDERING_BACKEND STREQUAL "OpenGL2")
+    set(NEEDS_ARGS
+      PseudoVolumeRendering
+      MinIntensityRendering
+      IntermixedUnstructuredGrid
+      FixedPointVolumeRayCastMapperCT
+      SimpleRayCast
+      )
+  else()
+    set(NEEDS_ARGS
+      HAVSVolumeMapper
+      MinIntensityRendering
+      IntermixedUnstructuredGrid
+      )
+  endif()
 
-set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
-set(TEMP ${WikiExamples_BINARY_DIR}/Testing/Temporary)
+  set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
+  set(TEMP ${WikiExamples_BINARY_DIR}/Testing/Temporary)
 
-if (VTK_RENDERING_BACKEND STREQUAL "OpenGL2")
-add_test(${KIT}-MinIntensityRendering ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestMinIntensityRendering ${DATA}/ironProt.vtk)
-add_test(${KIT}-FixedPointVolumeRayCastMapperCT ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestFixedPointVolumeRayCastMapperCT -MHA ${DATA}/FullHead.mhd -CT_Bone)
-else()
-add_test(${KIT}-HAVSVolumeMapper ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestHAVSVolumeMapper ${DATA}/ironProt.vtk ${DATA}/neghip.slc)
+  if (VTK_RENDERING_BACKEND STREQUAL "OpenGL2")
+    add_test(${KIT}-MinIntensityRendering ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+      TestMinIntensityRendering ${DATA}/ironProt.vtk)
+    add_test(${KIT}-FixedPointVolumeRayCastMapperCT ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+      TestFixedPointVolumeRayCastMapperCT -MHA ${DATA}/FullHead.mhd -CT_Bone)
+  else()
+    add_test(${KIT}-HAVSVolumeMapper ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+      TestHAVSVolumeMapper ${DATA}/ironProt.vtk ${DATA}/neghip.slc)
 
-add_test(${KIT}-MinIntensityRendering ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestMinIntensityRendering ${DATA}/ironProt.vtk)
-endif()
+    add_test(${KIT}-MinIntensityRendering ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+      TestMinIntensityRendering ${DATA}/ironProt.vtk)
+  endif()
 
-add_test(${KIT}-SimpleRayCast ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestSimpleRayCast ${DATA}/ironProt.vtk)
+  add_test(${KIT}-SimpleRayCast ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestSimpleRayCast ${DATA}/ironProt.vtk)
 
-add_test(${KIT}-PseudoVolumeRendering ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestPseudoVolumeRendering ${DATA}/combxyz.bin ${DATA}/combq.bin)
+  add_test(${KIT}-PseudoVolumeRendering ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestPseudoVolumeRendering ${DATA}/combxyz.bin ${DATA}/combq.bin)
 
-add_test(${KIT}-IntermixedUnstructuredGrid ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestIntermixedUnstructuredGrid ${DATA}/ironProt.vtk ${DATA}/neghip.slc)
+  add_test(${KIT}-IntermixedUnstructuredGrid ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestIntermixedUnstructuredGrid ${DATA}/ironProt.vtk ${DATA}/neghip.slc)
 
-include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
+  include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
 
 endif()

--- a/src/Cxx/Widgets/CMakeLists.txt
+++ b/src/Cxx/Widgets/CMakeLists.txt
@@ -1,18 +1,34 @@
 project (${WIKI}Widgets)
 
-if(NOT WikiExamples_BINARY_DIR)
-find_package(VTK REQUIRED)
-if(NOT VTK_USE_RENDERING)
-  message(FATAL_ERROR "Example ${PROJECT_NAME} requires VTK_USE_RENDERING.")
-endif()
-include(${VTK_USE_FILE})
+if(NOT VTK_BINARY_DIR)
+  set(VTK_LIBRARIES "")
+  find_package(VTK COMPONENTS
+    vtkCommonColor
+    vtkCommonCore
+    vtkCommonDataModel
+    vtkCommonTransforms
+    vtkFiltersCore
+    vtkFiltersSources
+    vtkIOImage
+    vtkIOXML
+    vtkImagingGeneral
+    vtkImagingHybrid
+    vtkImagingSources
+    vtkImagingStatistics
+    vtkImagingStencil
+    vtkInteractionStyle
+    vtkInteractionWidgets
+    vtkRenderingAnnotation
+    vtkRenderingCore
+    vtkRenderingFreeType
+    vtkRenderingOpenGL2
+    OPTIONAL_COMPONENTS
+    vtkTestingRendering
+    )
 endif()
 
-if("${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}" LESS 6.0)
-  set(KIT_LIBS vtkHybrid vtkWidgets)
-else()
-  set(KIT_LIBS ${VTK_LIBRARIES})
-endif()
+set(KIT_LIBS ${VTK_LIBRARIES})
+
 #
 # Build all .cxx files in the directory
 file(GLOB ALL_FILES *.cxx)
@@ -21,31 +37,37 @@ foreach(SOURCE_FILE ${ALL_FILES})
   string(REPLACE ${CMAKE_CURRENT_SOURCE_DIR}/ "" EXAMPLE ${TMP})
   add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
   target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
+  if (NOT VTK_VERSION VERSION_LESS "8.90.0")
+    vtk_module_autoinit(
+      TARGETS ${WIKI}${EXAMPLE}
+      MODULES ${VTK_LIBRARIES}
+      )
+  endif()
 endforeach()
 
 if (BUILD_TESTING)
-# Testing
-set(KIT Widgets)
+  # Testing
+  set(KIT Widgets)
 
-set(NEEDS_ARGS
-  CheckerboardWidget
-  OrientationMarkerWidget
-  Slicer2D
-  RectilinearWipeWidget
-)
+  set(NEEDS_ARGS
+    CheckerboardWidget
+    OrientationMarkerWidget
+    Slicer2D
+    RectilinearWipeWidget
+    )
 
-set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
-add_test(${KIT}-OrientationMarkerWidget ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestOrientationMarkerWidget ${DATA}/Bunny.vtp)
+  set(DATA ${WikiExamples_SOURCE_DIR}/src/Testing/Data)
+  add_test(${KIT}-OrientationMarkerWidget ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestOrientationMarkerWidget ${DATA}/Bunny.vtp)
 
-add_test(${KIT}-RectilinearWipeWidget ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestRectilinearWipeWidget ${DATA}/Gourds2.jpg ${DATA}/Ox.jpg)
+  add_test(${KIT}-RectilinearWipeWidget ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestRectilinearWipeWidget ${DATA}/Gourds2.jpg ${DATA}/Ox.jpg)
 
-add_test(${KIT}-CheckerboardWidget ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestCheckerboardWidget ${DATA}/Gourds2.jpg ${DATA}/Ox.jpg)
+  add_test(${KIT}-CheckerboardWidget ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestCheckerboardWidget ${DATA}/Gourds2.jpg ${DATA}/Ox.jpg)
 
-add_test(${KIT}-Slider2D ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
-  TestSlider2D -E 25)
-include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
+  add_test(${KIT}-Slider2D ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KIT}CxxTests
+    TestSlider2D -E 25)
+  include(${WikiExamples_SOURCE_DIR}/CMake/ExamplesTesting.cmake)
 
 endif()


### PR DESCRIPTION
This MR changed all CMakeLists.txt files got support he standalone
build uder the new vtk module system.

All CMakeLists.txt files were changed to use the new and old vtk
module system,

A new Wiki macro was added, AddOptionalIfInLibrary.cmake. This macro
checks to see if an optional module is included in the VTK_LIBRARIES.

A new Wiki macro was added, WikiLoadMacros.cmake. This macro loads all of the example macros. With this, the includes could be removed frm the individual CMakeLists.txt file.