### PR TITLE
Update CMakeLists.txt files to enable Qt builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ else()
 endif()
 
 # Display VTK version
-find_package(VTK CONFIG QUIET) 
+find_package(VTK CONFIG QUIET)
 if (NOT VTK_FOUND)
   message("Skipping Cube: ${VTK_NOT_FOUND_MESSAGE}")
 endif()
@@ -133,19 +133,21 @@ add_subdirectory(src/Cxx/Widgets)
 
 if(vtkGUISupportQt_LOADED OR TARGET VTK::GUISupportQt)
   message(STATUS "VTKWikiExamples: Building Qt examples")
-  if(${VTK_VERSION} VERSION_GREATER "6" AND VTK_QT_VERSION VERSION_GREATER "4")
+  if (VTK_VERSION VERSION_LESS "8.90.0")
     # Instruct CMake to run moc automatically when needed.
     set(CMAKE_AUTOMOC ON)
-    # We have ui files, this will bring in the macro: qt5_wrap_ui
-    find_package(Qt5Widgets REQUIRED QUIET)
   else()
-    find_package(Qt4 REQUIRED)
-    include(${QT_USE_FILE})
+    # Instruct CMake to run moc automatically when needed.
+    set(CMAKE_AUTOMOC ON)
+    set(CMAKE_AUTOUIC ON)
   endif()
+  # We have ui files, this will bring in the macro: qt5_wrap_ui
+  find_package(Qt5Widgets REQUIRED QUIET)
   add_subdirectory(src/Cxx/Qt)
 else()
   message(STATUS "VTKWikiExamples: Not building Qt examples")
 endif()
+
 # Is git lfs installed?
 file(READ "${WikiExamples_SOURCE_DIR}/src/Testing/Data/GitLfsInstalled" data)
 if (NOT data STREQUAL "GitLfsInstalled")

--- a/src/Cxx/Qt/CMakeLists.txt
+++ b/src/Cxx/Qt/CMakeLists.txt
@@ -64,30 +64,17 @@ Requires_Module(SideBySideRenderWindowsQtDriver vtkViewsQt)
 Requires_Module(QImageToImageSource vtkRenderingQt)
 
 foreach(EXAMPLE_FILE ${ALL_UI_FILES})
-
   string(REPLACE ".ui" "" TMP ${EXAMPLE_FILE})
-
   string(REPLACE ${CMAKE_CURRENT_SOURCE_DIR}/ "" EXAMPLE ${TMP})
   set(UISrcs)
   set(MOCSrcs)
-
-  if(VTK_QT_VERSION VERSION_GREATER "4")
-    qt5_wrap_ui(UISrcs ${EXAMPLE}.ui)
-    # CMAKE_AUTOMOC in ON so the MocHdrs will be automatically wrapped.
-    add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}Driver.cxx ${EXAMPLE}.cxx ${UISrcs} ${EXAMPLE}.h)
-    if (Qt5Widgets_VERSION VERSION_LESS "5.11.0")
-      qt5_use_modules(${WIKI}${EXAMPLE} Core Gui Widgets)
-    else()
-      target_link_libraries(${WIKI}${EXAMPLE} Qt5::Core Qt5::Gui Qt5::Widgets)
-      if (VTK_VERSION VERSION_GREATER "8.8")
-        vtk_module_autoinit(
-          TARGETS ${WIKI}${EXAMPLE}
-          MODULES ${VTK_LIBRARIES}
-          )
-      endif()
-    endif()
+  qt5_wrap_ui(UISrcs ${EXAMPLE}.ui)
+  # CMAKE_AUTOMOC in ON so the MocHdrs will be automatically wrapped.
+  add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}Driver.cxx ${EXAMPLE}.cxx ${UISrcs} ${EXAMPLE}.h)
+  if (Qt5Widgets_VERSION VERSION_LESS "5.11.0")
+    qt5_use_modules(${WIKI}${EXAMPLE} Core Gui Widgets)
   else()
-    add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
+    target_link_libraries(${WIKI}${EXAMPLE} Qt5::Core Qt5::Gui Qt5::Widgets)
   endif()
   target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
   if (VTK_VERSION VERSION_GREATER "8.8")
@@ -96,36 +83,24 @@ foreach(EXAMPLE_FILE ${ALL_UI_FILES})
       MODULES ${VTK_LIBRARIES}
       )
   endif()
-    list(REMOVE_ITEM ALL_FILES ${CMAKE_CURRENT_SOURCE_DIR}/${EXAMPLE}Driver.cxx ${CMAKE_CURRENT_SOURCE_DIR}/${EXAMPLE}.cxx)
+  list(REMOVE_ITEM ALL_FILES ${CMAKE_CURRENT_SOURCE_DIR}/${EXAMPLE}Driver.cxx ${CMAKE_CURRENT_SOURCE_DIR}/${EXAMPLE}.cxx)
 endforeach()
 
 # Build all remaining .cxx files.
 foreach(EXAMPLE_FILE ${ALL_FILES})
   string(REPLACE ".cxx" "" TMP ${EXAMPLE_FILE})
   string(REPLACE ${CMAKE_CURRENT_SOURCE_DIR}/ "" EXAMPLE ${TMP})
-
-  if(VTK_QT_VERSION VERSION_GREATER "4")
-    add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
-    if (Qt5Widgets_VERSION VERSION_LESS "5.11.0")
-      qt5_use_modules(${WIKI}${EXAMPLE} Core Gui Widgets)
-    else()
-      target_link_libraries(${WIKI}${EXAMPLE} Qt5::Core Qt5::Gui Qt5::Widgets)
-      if (VTK_VERSION VERSION_GREATER "8.8")
-        vtk_module_autoinit(
-          TARGETS ${WIKI}${EXAMPLE}
-          MODULES ${VTK_LIBRARIES}
-          )
-      endif()
-    endif()
-      target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
-    else()
-      add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
-      target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
-      if (VTK_VERSION VERSION_GREATER "8.8")
-        vtk_module_autoinit(
-          TARGETS ${WIKI}${EXAMPLE}
-          MODULES ${VTK_LIBRARIES}
-          )
-      endif()
-    endif()
+  add_executable(${WIKI}${EXAMPLE} ${EXECUTABLE_FLAG} ${EXAMPLE}.cxx)
+  if (Qt5Widgets_VERSION VERSION_LESS "5.11.0")
+    qt5_use_modules(${WIKI}${EXAMPLE} Core Gui Widgets)
+  else()
+    target_link_libraries(${WIKI}${EXAMPLE} Qt5::Core Qt5::Gui Qt5::Widgets)
+  endif()
+  target_link_libraries(${WIKI}${EXAMPLE} ${KIT_LIBS})
+  if (VTK_VERSION VERSION_GREATER "8.8")
+  vtk_module_autoinit(
+    TARGETS ${WIKI}${EXAMPLE}
+    MODULES ${VTK_LIBRARIES}
+    )
+  endif()
 endforeach()


### PR DESCRIPTION
@lorensen These changes allow Qt to build with VTK 8.90 and VTK 8.0. I have tested on VTK 8.90, VTK 8.2 with Qt 5.12. Please note that I have removed the Qt4 references/logic so these files are consistent with the web template.

I hope this doesn't  break what you are doing wrt the remote modules!