### PR TITLE
ImageActor should be opaque for the HardwareSelector to work

### DIFF
--- a/src/Cxx/Images/PickPixel2.cxx
+++ b/src/Cxx/Images/PickPixel2.cxx
@@ -225,7 +225,10 @@ int main(int argc, char* argv[])
 
   // disable interpolation, so we can see each pixel
   imageActor->InterpolateOff();
-
+  
+  // Image should be opaque for the HardwareSelector to work
+  imageActor->ForceOpaqueOn();
+  
   // Visualize
   auto renderWindowInteractor =
       vtkSmartPointer<vtkRenderWindowInteractor>::New();


### PR DESCRIPTION
The PropPicker (HardwareSelector) does not work for the automatically generate noise image.
Adding imageActor->ForceOpaqueOn() solves the issue.