### PR TITLE
Remove redundant OrthogonalizeViewUp calls

### DIFF
--- a/src/Cxx/Rendering/Shadows.cxx
+++ b/src/Cxx/Rendering/Shadows.cxx
@@ -155,7 +155,6 @@ int main(int argc, char *argv[])
   renderer->GetActiveCamera()->SetPosition(-0.2,0.2,1);
   renderer->GetActiveCamera()->SetFocalPoint(0,0,0);
   renderer->GetActiveCamera()->SetViewUp(0,1,0);
-  renderer->GetActiveCamera()->OrthogonalizeViewUp();
   renderer->ResetCamera();
   renderer->GetActiveCamera()->Dolly(2.25);
   renderer->ResetCameraClippingRange();

--- a/src/Python/Rendering/Shadows.py
+++ b/src/Python/Rendering/Shadows.py
@@ -157,7 +157,6 @@ def main():
     renderer.GetActiveCamera().SetPosition(-0.2, 0.2, 1)
     renderer.GetActiveCamera().SetFocalPoint(0, 0, 0)
     renderer.GetActiveCamera().SetViewUp(0, 1, 0)
-    renderer.GetActiveCamera().OrthogonalizeViewUp()
     renderer.ResetCamera()
     renderer.GetActiveCamera().Dolly(2.25)
     renderer.ResetCameraClippingRange()


### PR DESCRIPTION
SetViewUp method already orthogonalizes ViewUp vector by calling ComputeViewTransform(), which calls Transform->SetupCamera().

OrthogonalizeViewUp() is not called after SetViewUp in any other examples or tests.