### PR TITLE
Remove use of __APPLE_CC__

### DIFF
--- a/src/Cxx/Untested/HasBugs/vtkglut.cxx
+++ b/src/Cxx/Untested/HasBugs/vtkglut.cxx
@@ -1,7 +1,7 @@
-#ifndef __APPLE_CC__
-#include <GL/glut.h>
+#if defined(__APPLE__)
+#include <GLUT/glut.h>
 #else
-#include <glut.h>
+#include <GL/glut.h>
 #endif
 #include <vtkActor.h>
 #include <vtkCamera.h>


### PR DESCRIPTION
__APPLE_CC__ is an obsolete macro for clang version. Instead, conditionalize by platform, not compiler. Hoisted the same snippit from VTK itself.