### PR TITLE
VTK 90 replace SetEnvironmentCubeMap()

### DIFF
--- a/src/Cxx/Rendering/PhysicallyBasedRendering.cxx
+++ b/src/Cxx/Rendering/PhysicallyBasedRendering.cxx
@@ -46,6 +46,10 @@
 #include <sstream>
 #include <string>
 
+#if VTK_VERSION_NUMBER >= 90000000000ULL
+#define VTK_VER_GT_8_90 1
+#endif
+
 namespace {
 /**
  * Show the command lime parameters.
@@ -404,7 +408,11 @@ int main(int argc, char* argv[])
   actor->GetProperty()->SetNormalScale(normalScale);
 
   renderer->UseImageBasedLightingOn();
+#if VTK_VER_GT_8_90
+  renderer->SetEnvironmentTexture(cubemap);
+#else
   renderer->SetEnvironmentCubeMap(cubemap);
+#endif
   renderer->SetBackground(colors->GetColor3d("BkgColor").GetData());
   renderer->AddActor(actor);
 

--- a/src/Cxx/Rendering/Skybox_PBR.cxx
+++ b/src/Cxx/Rendering/Skybox_PBR.cxx
@@ -43,6 +43,10 @@
 #include <string>
 #include <vector>
 
+#if VTK_VERSION_NUMBER >= 90000000000ULL
+#define VTK_VER_GT_8_90 1
+#endif
+
 namespace {
 /**
  * Show the command lime parameters.
@@ -278,7 +282,11 @@ int main(int argc, char* argv[])
   actor->SetMapper(mapper);
 
   renderer->UseImageBasedLightingOn();
+#if VTK_VER_GT_8_90
+  renderer->SetEnvironmentTexture(cubemap);
+#else
   renderer->SetEnvironmentCubeMap(cubemap);
+#endif
   actor->GetProperty()->SetInterpolationToPBR();
 
   // configure the basic properties

--- a/src/Python/Rendering/PhysicallyBasedRendering.py
+++ b/src/Python/Rendering/PhysicallyBasedRendering.py
@@ -166,7 +166,10 @@ def main():
     actor.GetProperty().SetNormalScale(normalScale)
 
     renderer.UseImageBasedLightingOn()
-    renderer.SetEnvironmentCubeMap(cubemap)
+    if vtk.VTK_VERSION_NUMBER >= 90000000000:
+        renderer.SetEnvironmentTexture(cubemap)
+    else:
+        renderer.SetEnvironmentCubeMap(cubemap)
     renderer.SetBackground(colors.GetColor3d("BkgColor"))
     renderer.AddActor(actor)
 

--- a/src/Python/Rendering/Skybox_PBR.py
+++ b/src/Python/Rendering/Skybox_PBR.py
@@ -103,7 +103,10 @@ def main():
     actor.SetMapper(mapper)
 
     renderer.UseImageBasedLightingOn()
-    renderer.SetEnvironmentCubeMap(cubemap)
+    if vtk.VTK_VERSION_NUMBER >= 90000000000:
+        renderer.SetEnvironmentTexture(cubemap)
+    else:
+        renderer.SetEnvironmentCubeMap(cubemap)
     actor.GetProperty().SetInterpolationToPBR()
 
     # configure the basic properties


### PR DESCRIPTION
In in VTK 90+, vtkRenderer->SetEnvironmentCubeMap() has been replaced by vtkRenderer->SetEnvironmentTexture()